### PR TITLE
ContactFetchJob: clear local contacts after update

### DIFF
--- a/src/engine/contactsengine.cpp
+++ b/src/engine/contactsengine.cpp
@@ -262,6 +262,7 @@ public:
         QList<QContact> contacts;      {
             QMutexLocker locker(mutex);
             contacts = m_contacts;
+            m_contacts.clear();
         }
         QContactManagerEngine::updateContactFetchRequest(
                 m_request,


### PR DESCRIPTION
This fixes a crash happening when a ContactFetchJob changes state to
finished if an update occurred before. I'm not sure, though, why the bug occurred in the first place, and whether this change is correct. What I can say, is that the crash is no longer occurring. :-)

This is the backtrace of the crash (unfortunately debug symbols for
qtcontacts-sqlite are missing):

    Thread 1 "address-book-ap" received signal SIGSEGV, Segmentation fault.
    QtPrivate::RefCount::ref (this=0x18) at ../../include/QtCore/../../src/corelib/tools/qrefcount.h:55
    55	../../include/QtCore/../../src/corelib/tools/qrefcount.h: No such file or directory.
    (gdb) bt
    #0  QtPrivate::RefCount::ref (this=0x18) at ../../include/QtCore/../../src/corelib/tools/qrefcount.h:55
    #1  0x0000007fb6d45104 in QVector<QPersistentModelIndexData*>::QVector (this=0x7fffffde90, v=...) at ../../include/QtCore/../../src/corelib/tools/qvector.h:359
    #2  0x0000007fb6d45f80 in QStack<QVector<QPersistentModelIndexData*> >::pop (this=this@entry=0x63d4b0) at ../../include/QtCore/../../src/corelib/tools/qstack.h:62
    #3  0x0000007fb6d3f0bc in QAbstractItemModelPrivate::itemsMoved (this=this@entry=0x63d430, sourceParent=..., sourceFirst=sourceFirst@entry=15941232, sourceLast=sourceLast@entry=0, destinationParent=...,
        destinationChild=destinationChild@entry=2, orientation=orientation@entry=Qt::Vertical) at itemmodels/qabstractitemmodel.cpp:797
    #4  0x0000007fb6d42698 in QAbstractItemModel::endMoveRows (this=this@entry=0x63d370) at itemmodels/qabstractitemmodel.cpp:2985
    #5  0x0000007fa55ccc40 in QDeclarativeContactModel::fetchRequestStateChanged (this=this@entry=0x63d370, newState=QtContacts::QContactAbstractRequest::FinishedState) at qdeclarativecontactmodel.cpp:1078
    #6  0x0000007fa55cd39c in QDeclarativeContactModel::fetchRequestStateChanged (newState=<optimized out>, this=0x63d370) at qdeclarativecontactmodel.cpp:1037
    #7  QDeclarativeContactModel::qt_static_metacall (_o=0x63d370, _c=<optimized out>, _id=<optimized out>, _a=0x7fffffe248) at .moc/moc_qdeclarativecontactmodel_p.cpp:349
    #8  0x0000007fb6dbcdcc in QMetaObject::activate (sender=0x7fffffe23c, signalOffset=<optimized out>, local_signal_index=local_signal_index@entry=0, argv=argv@entry=0x7fffffe258) at kernel/qobject.cpp:3804
    #9  0x0000007fb6dbd434 in QMetaObject::activate (sender=<optimized out>, m=<optimized out>, local_signal_index=local_signal_index@entry=0, argv=argv@entry=0x7fffffe258) at kernel/qobject.cpp:3657
    #10 0x0000007fa54d244c in QtContacts::QContactAbstractRequest::stateChanged (this=<optimized out>, _t1=QtContacts::QContactAbstractRequest::InactiveState) at .moc/moc_qcontactabstractrequest.cpp:219
    #11 0x0000007fb6d9a078 in QMetaMethod::invoke (this=0x7fffffe650, this@entry=0x7fffffe780, object=0x0, object@entry=0x7fffffe790, connectionType=Qt::AutoConnection, connectionType@entry=1866682664,
        returnValue=..., val0=..., val1=..., val2=..., val3=..., val4=..., val5=..., val6=..., val7=..., val8=..., val9=...) at kernel/qmetaobject.cpp:2308
    #12 0x0000007fb6d9f094 in QMetaObject::invokeMethod (obj=0x7fffffe790, obj@entry=0xff13b0, member=0x0, member@entry=0x7fa550e618 "stateChanged", type=1866682664, type@entry=Qt::DirectConnection, ret=...,
        val0=..., val1=..., val2=..., val3=..., val4=..., val5=..., val6=..., val7=..., val8=..., val9=...) at kernel/qmetaobject.cpp:1522
    #13 0x0000007fa54ffaf4 in QMetaObject::invokeMethod (val9=..., val8=..., val7=..., val6=..., val5=..., val4=..., val3=..., val2=..., val1=..., val0=..., type=Qt::DirectConnection,
        member=0x7fa550e618 "stateChanged", obj=0xff13b0) at /usr/include/aarch64-linux-gnu/qt5/QtCore/qobjectdefs.h:445
    #14 QtContacts::QContactManagerEngine::updateContactFetchRequest (req=0xff13b0, result=..., error=QtContacts::QContactManager::NoError, newState=QtContacts::QContactAbstractRequest::InactiveState)
        at qcontactmanagerengine.cpp:1954
    #15 0x0000007fa4d2572c in JobThread::event(QEvent*) () from /usr/lib/aarch64-linux-gnu/qt5/plugins/contacts/libqtcontacts_sqlite.so
    #16 0x0000007fb6d8d494 in QCoreApplication::notifyInternal2 (receiver=0x6f43a0, event=0x7f8408d7d0) at kernel/qcoreapplication.cpp:1088
    #17 0x0000007fb6d8d6cc in QCoreApplication::sendEvent (receiver=<optimized out>, event=event@entry=0x7f8408d7d0) at kernel/qcoreapplication.cpp:1476
    #18 0x0000007fb6d901bc in QCoreApplicationPrivate::sendPostedEvents (receiver=receiver@entry=0x0, event_type=event_type@entry=0, data=0x43d1c0) at kernel/qcoreapplication.cpp:1825
    #19 0x0000007fb6d90684 in QCoreApplication::sendPostedEvents (receiver=receiver@entry=0x0, event_type=event_type@entry=0) at kernel/qcoreapplication.cpp:1679
    #20 0x0000007fb6dec550 in postEventSourceDispatch (s=0x546dc0) at kernel/qeventdispatcher_glib.cpp:276
    #21 0x0000007fb601f29c in g_main_context_dispatch () from /lib/aarch64-linux-gnu/libglib-2.0.so.0
    #22 0x0000007fb601f4f0 in ?? () from /lib/aarch64-linux-gnu/libglib-2.0.so.0
    #23 0x0000000000000001 in ?? ()
    Backtrace stopped: previous frame identical to this frame (corrupt stack?)

This was reported as https://bugreports.qt.io/browse/QTBUG-97048, but it
looks like it a bug in qtcontacts-sqlite instead.