### PR TITLE
engine: add a config option to load the ICU extension

### DIFF
--- a/src/engine/engine.pro
+++ b/src/engine/engine.pro
@@ -25,6 +25,11 @@ isEmpty(PKGCONFIG_LIB) {
     message("PKGCONFIG_LIB is unset, assuming $$PKGCONFIG_LIB")
 }
 
+CONFIG(load_icu) {
+    PKGCONFIG += sqlite3
+    DEFINES += QTCONTACTS_SQLITE_LOAD_ICU
+}
+
 # we hardcode this for Qt4 as there's no GenericDataLocation offered by QDesktopServices
 DEFINES += 'QTCONTACTS_SQLITE_PRIVILEGED_DIR=\'\"privileged\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"Contacts/qtcontacts-sqlite\"\''


### PR DESCRIPTION
I started to wonder if the reason why case-insensitive search did not work (which I'm trying to address in https://github.com/sailfishos/qtcontacts-sqlite/pull/2) could lie in not having the sqlite ICU extension loaded.

So here's a patch that enables it; this clears the warnings like
```
"Query failed: no such function: icu_load_collation Unable to execute statement\nSELECT icu_load_collation('it_IT', 'localeCollation')"
"Failed to configure collation for locale it_IT:  "
```
which I was seeing before. Unfortunately it does not fix the case-sensitiveness of the search, but it might improve sorting the contact list in some locales.

I don't know why SailfishOS does not need it (maybe you are using a specially built sqlite3 library which has this extension built-in?). :-)