### PR TITLE
[qtcontacts-sqlite] Don't try loading sqlite icu extension by default. JB#57486

### DIFF
--- a/rpm/qtcontacts-sqlite-qt5.spec
+++ b/rpm/qtcontacts-sqlite-qt5.spec
@@ -10,7 +10,6 @@ BuildRequires: pkgconfig(Qt5Sql)
 BuildRequires: pkgconfig(Qt5DBus)
 BuildRequires: pkgconfig(Qt5Contacts) >= 5.2.0
 BuildRequires: pkgconfig(mlite5)
-BuildRequires: pkgconfig(sqlite3)
 Requires: qt5-plugin-sqldriver-sqlite
 
 %description

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -53,7 +53,9 @@
 
 #include <QtDebug>
 
+#ifdef QTCONTACTS_SQLITE_LOAD_ICU
 #include <sqlite3.h>
+#endif
 
 static const char *setupEncoding =
         "\n PRAGMA encoding = \"UTF-16\";";
@@ -2542,6 +2544,7 @@ static bool upgradeDatabase(QSqlDatabase &database, ContactsDatabase *cdb)
 
 static bool configureDatabase(QSqlDatabase &database, QString &localeName)
 {
+#ifdef QTCONTACTS_SQLITE_LOAD_ICU
     // Load the ICU extension
     QVariant v = database.driver()->handle();
     if (v.isValid()) {
@@ -2560,6 +2563,7 @@ static bool configureDatabase(QSqlDatabase &database, QString &localeName)
             }
         }
     }
+#endif
 
     if (!execute(database, QLatin1String(setupEncoding))
         || !execute(database, QLatin1String(setupTempStore))

--- a/src/engine/engine.pro
+++ b/src/engine/engine.pro
@@ -25,7 +25,10 @@ isEmpty(PKGCONFIG_LIB) {
     message("PKGCONFIG_LIB is unset, assuming $$PKGCONFIG_LIB")
 }
 
-PKGCONFIG += sqlite3
+CONFIG(load_icu) {
+    PKGCONFIG += sqlite3
+    DEFINES += QTCONTACTS_SQLITE_LOAD_ICU
+}
 
 # we hardcode this for Qt4 as there's no GenericDataLocation offered by QDesktopServices
 DEFINES += 'QTCONTACTS_SQLITE_PRIVILEGED_DIR=\'\"privileged\"\''


### PR DESCRIPTION
Seems I enabled this for all too hastily and whether the extension is
available or already built-in depends on the sqlite configuration.

The sqlite/ext/icu/README.txt tells how to create such an extension.
The code here, however, now fails on sailfish, though the sqlite itself is built
with ICU support. Executing "SELECT icu_load_collation('somelocale', 'localeCollation');"
succeeds the first time and second time it does a warning with a string
from the extension, proving also the extension is used.

This reverts commit 806cffe977f07dbcde80c0b25528734e9be0a8da.
This reverts commit 8c2f2960b8b5d57e21fa9120632f78c0fe1330de.

For reference https://github.com/sailfishos/qtcontacts-sqlite/pull/3 

@Tomin1 @spiiroin @mardy 