### PR TITLE
Fix a unit test, rename extension devel package and some cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.moc
 *.o
+*.so
 .*.swp
 Makefile
 moc_*

--- a/rpm/qtcontacts-sqlite-qt5.spec
+++ b/rpm/qtcontacts-sqlite-qt5.spec
@@ -1,5 +1,5 @@
 Name: qtcontacts-sqlite-qt5
-Version: 0.3.9
+Version: 0.3.20
 Release: 0
 Summary: SQLite-based plugin for QtPIM Contacts
 License: BSD
@@ -24,11 +24,13 @@ Requires:   %{name} = %{version}-%{release}
 %description tests
 This package contains unit tests for the qtcontacts-sqlite-qt5 library.
 
-%package extensions
+%package extensions-devel
 Summary:    QtContacts extension headers for qtcontacts-sqlite-qt5
 Requires:   %{name} = %{version}-%{release}
+Provides:   qtcontacts-sqlite-qt5-extensions > 0.3.19
+Obsoletes:  qtcontacts-sqlite-qt5-extensions <= 0.3.19
 
-%description extensions
+%description extensions-devel
 This package contains extension headers for the qtcontacts-sqlite-qt5 library.
 
 %prep
@@ -49,7 +51,7 @@ This package contains extension headers for the qtcontacts-sqlite-qt5 library.
 /opt/tests/qtcontacts-sqlite-qt5/*
 %{_libdir}/qtcontacts-sqlite-qt5/libtestdlgg.so
 
-%files extensions
+%files extensions-devel
 %{_libdir}/pkgconfig/qtcontacts-sqlite-qt5-extensions.pc
 %{_includedir}/qtcontacts-sqlite-qt5-extensions/*
 

--- a/rpm/qtcontacts-sqlite-qt5.spec
+++ b/rpm/qtcontacts-sqlite-qt5.spec
@@ -15,11 +15,6 @@ Requires: qt5-plugin-sqldriver-sqlite
 %description
 %{summary}.
 
-%files
-%defattr(-,root,root,-)
-%license LICENSE.BSD
-%{_libdir}/qt5/plugins/contacts/*.so*
-
 %package tests
 Summary:    Unit tests for qtcontacts-sqlite-qt5
 BuildRequires:  pkgconfig(Qt5Test)
@@ -29,11 +24,6 @@ Requires:   %{name} = %{version}-%{release}
 %description tests
 This package contains unit tests for the qtcontacts-sqlite-qt5 library.
 
-%files tests
-%defattr(-,root,root,-)
-/opt/tests/qtcontacts-sqlite-qt5/*
-%{_libdir}/qtcontacts-sqlite-qt5/libtestdlgg.so
-
 %package extensions
 Summary:    QtContacts extension headers for qtcontacts-sqlite-qt5
 Requires:   %{name} = %{version}-%{release}
@@ -41,19 +31,25 @@ Requires:   %{name} = %{version}-%{release}
 %description extensions
 This package contains extension headers for the qtcontacts-sqlite-qt5 library.
 
-%files extensions
-%defattr(-,root,root,-)
-%{_libdir}/pkgconfig/qtcontacts-sqlite-qt5-extensions.pc
-%{_includedir}/qtcontacts-sqlite-qt5-extensions/*
-
-
 %prep
 %setup -q -n %{name}-%{version}
 
 %build
 %qmake5 "VERSION=%{version}" "PKGCONFIG_LIB=%{_lib}"
-make %{?_smp_mflags}
+%make_build
 
 %install
 %qmake5_install
+
+%files
+%license LICENSE.BSD
+%{_libdir}/qt5/plugins/contacts/*.so*
+
+%files tests
+/opt/tests/qtcontacts-sqlite-qt5/*
+%{_libdir}/qtcontacts-sqlite-qt5/libtestdlgg.so
+
+%files extensions
+%{_libdir}/pkgconfig/qtcontacts-sqlite-qt5-extensions.pc
+%{_includedir}/qtcontacts-sqlite-qt5-extensions/*
 

--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -32,7 +32,6 @@
 
 #include "contactreader.h"
 #include "contactsengine.h"
-#include "trace_p.h"
 
 #include "../extensions/qtcontacts-extensions.h"
 #include "../extensions/qcontactdeactivated.h"
@@ -1023,7 +1022,7 @@ static QString buildWhere(const QContactCollectionFilter &filter, QVariantList *
         return statement + QStringLiteral(")");
     } else {
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with too large collection ID list"));
+        qWarning() << "Cannot buildWhere with too large collection ID list";
         return QStringLiteral("FALSE");
     }
 }
@@ -1038,14 +1037,14 @@ static QString buildWhere(
 {
     if (filter.matchFlags() & QContactFilter::MatchKeypadCollation) {
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with filter requiring keypad collation"));
+        qWarning() << "Cannot buildWhere with filter requiring keypad collation";
         return QStringLiteral("FAILED");
     }
 
     const DetailInfo &detail(detailInformation(filter.detailType()));
     if (detail.detailType == QContactDetail::TypeUndefined) {
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown detail type: %1").arg(filter.detailType()));
+        qWarning() << "Cannot buildWhere with unknown detail type:" << filter.detailType();
         return QStringLiteral("FAILED");
     }
 
@@ -1057,7 +1056,7 @@ static QString buildWhere(
     const FieldInfo &field(fieldInformation(detail, filter.detailField()));
     if (field.field == invalidField) {
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown detail field: %1").arg(filter.detailField()));
+        qWarning() << QString::fromLatin1("Cannot buildWhere with unknown detail field: %1").arg(filter.detailField());
         return QStringLiteral("FAILED");
     }
 
@@ -1134,7 +1133,7 @@ static QString buildWhere(
                         }
                     }
                 } else {
-                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unsupported flags matching contact status flags"));
+                    qWarning() << "Unsupported flags matching contact status flags";
                     break;
                 }
 
@@ -1190,7 +1189,7 @@ static QString buildWhere(
                 bindValue = ContactsEngine::normalizedPhoneNumber(stringValue);
                 if (bindValue.isEmpty()) {
                     *failed = true;
-                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed with invalid phone number: %1").arg(stringValue));
+                    qWarning() << QString::fromLatin1("Failed with invalid phone number: %1").arg(stringValue);
                     return QStringLiteral("FAILED");
                 }
                 if (caseInsensitive) {
@@ -1274,7 +1273,7 @@ static QString buildWhere(
     } while (false);
 
     *failed = true;
-    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to buildWhere with DetailFilter detail: %1 field: %2").arg(filter.detailType()).arg(filter.detailField()));
+    qWarning() << QString::fromLatin1("Failed to buildWhere with DetailFilter detail: %1 field: %2").arg(filter.detailType()).arg(filter.detailField());
     return QStringLiteral("FALSE");
 }
 
@@ -1283,7 +1282,7 @@ static QString buildWhere(const QContactDetailRangeFilter &filter, bool queryCon
     const DetailInfo &detail(detailInformation(filter.detailType()));
     if (detail.detailType == QContactDetail::TypeUndefined) {
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown detail type: %1").arg(filter.detailType()));
+        qWarning() << QString::fromLatin1("Cannot buildWhere with unknown detail type:") << filter.detailType();
         return QStringLiteral("FAILED");
     }
 
@@ -1295,7 +1294,7 @@ static QString buildWhere(const QContactDetailRangeFilter &filter, bool queryCon
     const FieldInfo &field(fieldInformation(detail, filter.detailField()));
     if (field.field == invalidField) {
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown detail field: %1").arg(filter.detailField()));
+        qWarning() << QString::fromLatin1("Cannot buildWhere with unknown detail field:") <<  filter.detailField();
         return QStringLiteral("FAILED");
     }
 
@@ -1367,7 +1366,7 @@ static QString buildWhere(const QContactIdFilter &filter, ContactsDatabase &db, 
     const QList<QContactId> &filterIds(filter.ids());
     if (filterIds.isEmpty()) {
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with empty contact ID list"));
+        qWarning() << "Cannot buildWhere with empty contact ID list";
         return QStringLiteral("FALSE");
     }
 
@@ -1391,7 +1390,7 @@ static QString buildWhere(const QContactIdFilter &filter, ContactsDatabase &db, 
         QString transientTable;
         if (!db.createTransientContactIdsTable(table, varIds, &transientTable)) {
             *failed = true;
-            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere due to transient table failure"));
+            qWarning() << "Cannot buildWhere due to transient table failure";
             return QStringLiteral("FALSE");
         }
 
@@ -1419,7 +1418,7 @@ static QString buildWhere(const QContactRelationshipFilter &filter, QVariantList
 
     if (!rci.managerUri().isEmpty() && !rci.managerUri().startsWith(QStringLiteral("qtcontacts:org.nemomobile.contacts.sqlite"))) {
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with invalid manager URI: %1").arg(rci.managerUri()));
+        qWarning() << "Cannot buildWhere with invalid manager URI:" << rci.managerUri();
         return QStringLiteral("FALSE");
     }
 
@@ -1541,7 +1540,7 @@ static QString buildWhere(const QContactChangeLogFilter &filter, QVariantList *b
     }
 
     *failed = true;
-    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with changelog filter on removed timestamps"));
+    qWarning() << "Cannot buildWhere with changelog filter on removed timestamps";
     return QStringLiteral("FALSE");
 }
 
@@ -1641,7 +1640,7 @@ static QString buildContactWhere(const QContactFilter &filter, ContactsDatabase 
         return buildWhere(static_cast<const QContactCollectionFilter &>(filter), bindings, failed);
     default:
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown filter type: %1").arg(filter.type()));
+        qWarning() << "Cannot buildWhere with unknown filter type:" << filter.type();
         return QStringLiteral("FALSE");
     }
 }
@@ -1676,7 +1675,7 @@ static QString buildDetailWhere(
                         globalPresenceRequired);
         } else {
             *failed = true;
-            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot build detail query with mismatched details type: %1 %2").arg(detailType).arg(detailFilter.detailType()));
+            qWarning() << "Cannot build detail query with mismatched details type:" << detailType << detailFilter.detailType();
             return QStringLiteral("FALSE");
         }
     }
@@ -1687,7 +1686,7 @@ static QString buildDetailWhere(
             return buildWhere(detailFilter, false, bindings, failed);
         } else {
             *failed = true;
-            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot build detail query with mismatched details type: %1 != %2").arg(detailType).arg(detailFilter.detailType()));
+            qWarning() << QString::fromLatin1("Cannot build detail query with mismatched details type: %1 != %2").arg(detailType).arg(detailFilter.detailType());
             return QStringLiteral("FALSE");
         }
     }
@@ -1717,11 +1716,11 @@ static QString buildDetailWhere(
     case QContactFilter::RelationshipFilter:
     case QContactFilter::IdFilter:
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot build a detail query with a non-detail filter type: %1").arg(filter.type()));
+        qWarning() << "Cannot build a detail query with a non-detail filter type:" << filter.type();
         return QStringLiteral("FALSE");
     default:
         *failed = true;
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown filter type: %1").arg(filter.type()));
+        qWarning() << "Cannot buildWhere with unknown filter type:" << filter.type();
         return QStringLiteral("FALSE");
     }
 }
@@ -1741,10 +1740,10 @@ static QString buildOrderBy(
 
     const DetailInfo &detail(detailInformation(order.detailType()));
     if (detail.detailType == QContactDetail::TypeUndefined) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildOrderBy with unknown detail type: %1").arg(order.detailType()));
+        qWarning() << "Cannot buildOrderBy with unknown detail type:" << order.detailType();
         return QString();
     } else if (detailType != QContactDetail::TypeUndefined && detail.detailType != detailType) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildOrderBy with unknown detail mismatched detail types: %1 != %2").arg(detailType).arg(order.detailType()));
+        qWarning() << QString::fromLatin1("Cannot buildOrderBy with unknown detail mismatched detail types: %1 != %2").arg(detailType).arg(order.detailType());
         return QString();
     }
 
@@ -1757,7 +1756,7 @@ static QString buildOrderBy(
 
     const FieldInfo &field(fieldInformation(detail, order.detailField()));
     if (field.field == invalidField) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildOrderBy with unknown detail field: %1").arg(order.detailField()));
+        qWarning() << "Cannot buildOrderBy with unknown detail field:" << order.detailField();
         return QString();
     }
 
@@ -1836,8 +1835,8 @@ static QString buildOrderBy(
     } else if (!detail.table || detailType != QContactDetail::TypeUndefined) {
         return result;
     } else {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("UNSUPPORTED SORTING: no join and not primary table for ORDER BY in query with: %1, %2")
-                   .arg(order.detailType()).arg(order.detailField()));
+        qWarning() << QString::fromLatin1("UNSUPPORTED SORTING: no join and not primary table for ORDER BY in query with: %1, %2")
+                   .arg(order.detailType()).arg(order.detailField());
     }
 
     return QString();
@@ -1954,7 +1953,7 @@ bool includesSelfId(const QContactFilter &filter)
         return includesSelfId(static_cast<const QContactIdFilter &>(filter));
 
     default:
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot includesSelfId with unknown filter type %1").arg(filter.type()));
+        qWarning() << "Cannot includesSelfId with unknown filter type" << filter.type();
         return false;
     }
 }
@@ -1999,7 +1998,7 @@ bool includesCollectionFilter(const QContactFilter &filter)
         return includesCollectionFilter(static_cast<const QContactUnionFilter &>(filter));
 
     default:
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot includesCollectionFilter with unknown filter type %1").arg(filter.type()));
+        qWarning() << "Cannot includesCollectionFilter with unknown filter type" << filter.type();
         return false;
     }
 }
@@ -2053,7 +2052,7 @@ bool includesDeleted(const QContactFilter &filter)
         return includesDeleted(static_cast<const QContactDetailFilter &>(filter));
 
     default:
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot includesDeleted with unknown filter type %1").arg(filter.type()));
+        qWarning() << "Cannot includesDeleted with unknown filter type" << filter.type();
         return false;
     }
 }
@@ -2108,7 +2107,7 @@ bool includesDeactivated(const QContactFilter &filter)
         return includesDeactivated(static_cast<const QContactDetailFilter &>(filter));
 
     default:
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot includesDeactivated with unknown filter type %1").arg(filter.type()));
+        qWarning() << "Cannot includesDeactivated with unknown filter type" << filter.type();
         return false;
     }
 }
@@ -2152,7 +2151,7 @@ bool includesIdFilter(const QContactFilter &filter)
         return true;
 
     default:
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot includesIdFilter with unknown filter type %1").arg(filter.type()));
+        qWarning() << "Cannot includesIdFilter with unknown filter type" << filter.type();
         return false;
     }
 }
@@ -2322,7 +2321,7 @@ QContactManager::Error ContactReader::readContacts(
     QString where = buildContactWhere(filter, m_database, table, QContactDetail::TypeUndefined, &bindings, &whereFailed,
                                       &transientModifiedRequired, &globalPresenceRequired);
     if (whereFailed) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create WHERE expression: invalid filter specification"));
+        qWarning() << "Failed to create WHERE expression: invalid filter specification";
         return QContactManager::UnspecifiedError;
     }
 
@@ -2471,16 +2470,16 @@ QContactManager::Error ContactReader::queryContacts(
 
     // Prepare the query for the contact properties
     if (!contactQuery.prepare(dataQueryStatement)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare query for contact data:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to prepare query for contact data:\n%1\nQuery:\n%2")
                 .arg(contactQuery.lastError().text())
-                .arg(dataQueryStatement));
+                .arg(dataQueryStatement);
         err = QContactManager::UnspecifiedError;
     } else {
         contactQuery.setForwardOnly(true);
         if (!ContactsDatabase::execute(contactQuery)) {
-            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to execute query for contact data:\n%1\nQuery:\n%2")
+            qWarning() << QString::fromLatin1("Failed to execute query for contact data:\n%1\nQuery:\n%2")
                     .arg(contactQuery.lastError().text())
-                    .arg(dataQueryStatement));
+                    .arg(dataQueryStatement);
             err = QContactManager::UnspecifiedError;
         } else {
             QContactFetchHint::OptimizationHints optimizationHints(fetchHint.optimizationHints());
@@ -2489,16 +2488,16 @@ QContactManager::Error ContactReader::queryContacts(
             if (fetchRelationships) {
                 // Prepare the query for the contact relationships
                 if (!relationshipQuery.prepare(relationshipQueryStatement)) {
-                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare query for relationships:\n%1\nQuery:\n%2")
+                    qWarning() << QString::fromLatin1("Failed to prepare query for relationships:\n%1\nQuery:\n%2")
                             .arg(relationshipQuery.lastError().text())
-                            .arg(relationshipQueryStatement));
+                            .arg(relationshipQueryStatement);
                     err = QContactManager::UnspecifiedError;
                 } else {
                     relationshipQuery.setForwardOnly(true);
                     if (!ContactsDatabase::execute(relationshipQuery)) {
-                        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare query for relationships:\n%1\nQuery:\n%2")
+                        qWarning() << QString::fromLatin1("Failed to prepare query for relationships:\n%1\nQuery:\n%2")
                                 .arg(relationshipQuery.lastError().text())
-                                .arg(relationshipQueryStatement));
+                                .arg(relationshipQueryStatement);
                         err = QContactManager::UnspecifiedError;
                     } else {
                         // Move to the first row
@@ -2850,18 +2849,18 @@ QContactManager::Error ContactReader::readDeletedContactIds(
                 if (filterOnField<QContactSyncTarget>(detailFilter, QContactSyncTarget::FieldSyncTarget)) {
                     syncTarget = detailFilter.value().toString();
                 } else {
-                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot readDeletedContactIds with unsupported detail filter type: %1").arg(detailFilter.detailType()));
+                    qWarning() << "Cannot readDeletedContactIds with unsupported detail filter type:" << detailFilter.detailType();
                     return QContactManager::UnspecifiedError;
                 }
             } else if (filterType == QContactFilter::CollectionFilter) {
                 const QContactCollectionFilter &collectionFilter(static_cast<const QContactCollectionFilter &>(partialFilter));
                 collectionIds = collectionFilter.collectionIds().toList();
                 if (collectionIds.size() > 1) {
-                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot readDeletedContactIds with more than one collection specified: %1").arg(collectionIds.size()));
+                    qWarning() << "Cannot readDeletedContactIds with more than one collection specified:" <<  collectionIds.size();
                     return QContactManager::UnspecifiedError;
                 }
             } else {
-                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot readDeletedContactIds with invalid filter type: %1").arg(filterType));
+                qWarning() << "Cannot readDeletedContactIds with invalid filter type:" << filterType;
                 return QContactManager::UnspecifiedError;
             }
         }
@@ -2896,9 +2895,9 @@ QContactManager::Error ContactReader::readDeletedContactIds(
     QSqlQuery query(m_database);
     query.setForwardOnly(true);
     if (!query.prepare(queryStatement)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare deleted contacts ids:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to prepare deleted contacts ids:\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(queryStatement));
+                .arg(queryStatement);
         return QContactManager::UnspecifiedError;
     }
 
@@ -2906,9 +2905,9 @@ QContactManager::Error ContactReader::readDeletedContactIds(
         query.bindValue(i, bindings.at(i));
 
     if (!ContactsDatabase::execute(query)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query deleted contacts ids\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to query deleted contacts ids\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(queryStatement));
+                .arg(queryStatement);
         return QContactManager::UnspecifiedError;
     }
 
@@ -2949,7 +2948,7 @@ QContactManager::Error ContactReader::readContactIds(
     QString where = buildContactWhere(filter, m_database, tableName, QContactDetail::TypeUndefined, &bindings,
                                       &failed, &transientModifiedRequired, &globalPresenceRequired);
     if (failed) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create WHERE expression: invalid filter specification"));
+        qWarning() << "Failed to create WHERE expression: invalid filter specification";
         return QContactManager::UnspecifiedError;
     }
 
@@ -2980,9 +2979,9 @@ QContactManager::Error ContactReader::readContactIds(
     QSqlQuery query(m_database);
     query.setForwardOnly(true);
     if (!query.prepare(queryString)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare contacts ids:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to prepare contacts ids:\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(queryString));
+                .arg(queryString);
         return QContactManager::UnspecifiedError;
     }
 
@@ -2990,9 +2989,9 @@ QContactManager::Error ContactReader::readContactIds(
         query.bindValue(i, bindings.at(i));
 
     if (!ContactsDatabase::execute(query)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query contacts ids\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to query contacts ids\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(queryString));
+                .arg(queryString);
         return QContactManager::UnspecifiedError;
     } else {
         debugFilterExpansion("Contact IDs selection:", queryString, bindings);
@@ -3086,9 +3085,9 @@ QContactManager::Error ContactReader::readRelationships(
     QSqlQuery query(m_database);
     query.setForwardOnly(true);
     if (!query.prepare(statement)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare relationships query:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to prepare relationships query:\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(statement));
+                .arg(statement);
         return QContactManager::UnspecifiedError;
     }
 
@@ -3096,8 +3095,8 @@ QContactManager::Error ContactReader::readRelationships(
         query.bindValue(i, bindings.at(i));
 
     if (!ContactsDatabase::execute(query)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query relationships: %1")
-                .arg(query.lastError().text()));
+        qWarning() << QString::fromLatin1("Failed to query relationships: %1")
+                .arg(query.lastError().text());
         return QContactManager::UnspecifiedError;
     }
 
@@ -3155,7 +3154,7 @@ QContactManager::Error ContactReader::readDetails(
                 &transientModifiedRequired,
                 &globalPresenceRequired);
     if (whereFailed) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create WHERE expression: invalid filter specification"));
+        qWarning() << "Failed to create WHERE expression: invalid filter specification";
         return QContactManager::UnspecifiedError;
     }
 
@@ -3188,9 +3187,9 @@ QContactManager::Error ContactReader::readDetails(
     QSqlQuery query(m_database);
     query.setForwardOnly(true);
     if (!query.prepare(statement)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare a unique details query: %1\n%2")
+        qWarning() << QString::fromLatin1("Failed to prepare a unique details query: %1\n%2")
                 .arg(query.lastError().text())
-                .arg(statement));
+                .arg(statement);
         return QContactManager::UnspecifiedError;
     }
 
@@ -3199,9 +3198,9 @@ QContactManager::Error ContactReader::readDetails(
     }
 
     if (!ContactsDatabase::execute(query)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query unique details\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to query unique details\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(statement));
+                .arg(statement);
         return QContactManager::UnspecifiedError;
     }
 
@@ -3277,9 +3276,9 @@ QContactManager::Error ContactReader::fetchCollections(
 
     QSqlQuery collectionsQuery(m_database);
     if (!collectionsQuery.prepare(collectionsQueryStatement)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare query for collection details:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to prepare query for collection details:\n%1\nQuery:\n%2")
                 .arg(collectionsQuery.lastError().text())
-                .arg(collectionsQueryStatement));
+                .arg(collectionsQueryStatement);
         return QContactManager::UnspecifiedError;
     }
 
@@ -3292,9 +3291,9 @@ QContactManager::Error ContactReader::fetchCollections(
 
     collectionsQuery.setForwardOnly(true);
     if (!ContactsDatabase::execute(collectionsQuery)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to execute query for collection details:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to execute query for collection details:\n%1\nQuery:\n%2")
                 .arg(collectionsQuery.lastError().text())
-                .arg(collectionsQueryStatement));
+                .arg(collectionsQueryStatement);
         return QContactManager::UnspecifiedError;
     }
 
@@ -3327,18 +3326,18 @@ QContactManager::Error ContactReader::fetchCollections(
 
         QSqlQuery metadataQuery(m_database);
         if (!metadataQuery.prepare(metadataStatement)) {
-            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare query for collection metadata details:\n%1\nQuery:\n%2")
+            qWarning() << QString::fromLatin1("Failed to prepare query for collection metadata details:\n%1\nQuery:\n%2")
                     .arg(metadataQuery.lastError().text())
-                    .arg(metadataStatement));
+                    .arg(metadataStatement);
             return QContactManager::UnspecifiedError;
         }
 
         metadataQuery.bindValue(":collectionId", dbId);
         metadataQuery.setForwardOnly(true);
         if (!ContactsDatabase::execute(metadataQuery)) {
-            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to execute query for collection metadata details:\n%1\nQuery:\n%2")
+            qWarning() << QString::fromLatin1("Failed to execute query for collection metadata details:\n%1\nQuery:\n%2")
                     .arg(metadataQuery.lastError().text())
-                    .arg(metadataStatement));
+                    .arg(metadataStatement);
             return QContactManager::UnspecifiedError;
         }
 
@@ -3386,18 +3385,18 @@ QContactManager::Error ContactReader::recordUnhandledChangeFlags(
 
     QSqlQuery query(m_database);
     if (!query.prepare(unhandledChangeFlagsStatement)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare query for record unhandled change flags:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to prepare query for record unhandled change flags:\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(unhandledChangeFlagsStatement));
+                .arg(unhandledChangeFlagsStatement);
         return QContactManager::UnspecifiedError;
     }
 
     query.bindValue(":collectionId", ContactCollectionId::databaseId(collectionId));
     query.setForwardOnly(true);
     if (!ContactsDatabase::execute(query)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to execute query for record unhandled change flags:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to execute query for record unhandled change flags:\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(unhandledChangeFlagsStatement));
+                .arg(unhandledChangeFlagsStatement);
         return QContactManager::UnspecifiedError;
     }
 
@@ -3430,9 +3429,9 @@ bool ContactReader::fetchOOB(const QString &scope, const QStringList &keys, QMap
     QSqlQuery query(m_database);
     query.setForwardOnly(true);
     if (!query.prepare(statement)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare OOB query:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to prepare OOB query:\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(statement));
+                .arg(statement);
         return false;
     }
 
@@ -3441,8 +3440,7 @@ bool ContactReader::fetchOOB(const QString &scope, const QStringList &keys, QMap
     }
 
     if (!ContactsDatabase::execute(query)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query OOB: %1")
-                .arg(query.lastError().text()));
+        qWarning() << "Failed to query OOB:" << query.lastError().text();
         return false;
     }
     while (query.next()) {
@@ -3460,8 +3458,8 @@ bool ContactReader::fetchOOB(const QString &scope, const QStringList &keys, QMap
                 // QString data
                 values->insert(key, QVariant(QString::fromUtf8(qUncompress(compressedData))));
             } else {
-                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Invalid compression type for OOB data:%1, key:%2")
-                        .arg(compressed).arg(key));
+                qWarning() << QString::fromLatin1("Invalid compression type for OOB data:%1, key:%2")
+                        .arg(compressed).arg(key);
             }
         } else {
             values->insert(key, value);
@@ -3479,15 +3477,15 @@ bool ContactReader::fetchOOBKeys(const QString &scope, QStringList *keys)
     QSqlQuery query(m_database);
     query.setForwardOnly(true);
     if (!query.prepare(statement)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare OOB query:\n%1\nQuery:\n%2")
+        qWarning() << QString::fromLatin1("Failed to prepare OOB query:\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
-                .arg(statement));
+                .arg(statement);
         return false;
     }
 
     if (!ContactsDatabase::execute(query)) {
-        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query OOB: %1")
-                .arg(query.lastError().text()));
+        qWarning() << QString::fromLatin1("Failed to query OOB: %1")
+                .arg(query.lastError().text());
         return false;
     }
     while (query.next()) {

--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -669,7 +669,9 @@ static int contextType(const QString &type)
 }
 
 template <typename T>
-static void readDetail(QContact *contact, QSqlQuery &query, quint32 contactId, quint32 detailId, bool syncable, const QContactCollectionId &apiCollectionId, bool relaxConstraints, bool keepChangeFlags, int offset)
+static void readDetail(QContact *contact, QSqlQuery &query, quint32 contactId, quint32 detailId,
+                       bool syncable, const QContactCollectionId &apiCollectionId, bool relaxConstraints,
+                       bool keepChangeFlags, int offset)
 {
     const quint32 collectionId = ContactCollectionId::databaseId(apiCollectionId);
     const bool aggregateContact(collectionId == ContactsDatabase::AggregateAddressbookCollectionId);
@@ -724,7 +726,10 @@ static void readDetail(QContact *contact, QSqlQuery &query, quint32 contactId, q
     }
 
     // If the detail is not aggregated from another, then its provenance should match its ID.
-    setValue(&detail, QContactDetail::FieldProvenance, aggregateContact ? provenance : QStringLiteral("%1:%2:%3").arg(collectionId).arg(contactId).arg(dbId));
+    setValue(&detail, QContactDetail::FieldProvenance,
+             aggregateContact
+             ? provenance
+             : QStringLiteral("%1:%2:%3").arg(collectionId).arg(contactId).arg(dbId));
 
     // Only report modifiable state for non-local contacts.
     // local contacts are always (implicitly) modifiable.
@@ -748,7 +753,8 @@ static void readDetail(QContact *contact, QSqlQuery &query, quint32 contactId, q
     // is intended for modification, so adding constraints prevents it from being used correctly.
     // Normal aggregate contact details are always immutable.
     if (!relaxConstraints) {
-        QContactManagerEngine::setDetailAccessConstraints(&detail, static_cast<QContactDetail::AccessConstraints>(accessConstraints));
+        QContactManagerEngine::setDetailAccessConstraints(&detail,
+                                                          static_cast<QContactDetail::AccessConstraints>(accessConstraints));
     }
 
     setValues(&detail, &query, offset);
@@ -766,7 +772,8 @@ static void appendUniqueDetail(QList<QContactDetail> *details, QSqlQuery &query)
     details->append(detail);
 }
 
-static QContactRelationship makeRelationship(const QString &type, quint32 firstId, quint32 secondId, const QString &manager_uri)
+static QContactRelationship makeRelationship(const QString &type, quint32 firstId, quint32 secondId,
+                                             const QString &manager_uri)
 {
     QContactRelationship relationship;
     relationship.setRelationshipType(type);
@@ -777,7 +784,9 @@ static QContactRelationship makeRelationship(const QString &type, quint32 firstI
     return relationship;
 }
 
-typedef void (*ReadDetail)(QContact *contact, QSqlQuery &query, quint32 contactId, quint32 detailId, bool syncable, const QContactCollectionId &collectionId, bool relaxConstraints, bool keepChangeFlags, int offset);
+typedef void (*ReadDetail)(QContact *contact, QSqlQuery &query, quint32 contactId, quint32 detailId, bool syncable,
+                           const QContactCollectionId &collectionId, bool relaxConstraints, bool keepChangeFlags,
+                           int offset);
 typedef void (*AppendUniqueDetail)(QList<QContactDetail> *details, QSqlQuery &query);
 
 struct DetailInfo
@@ -1589,7 +1598,8 @@ static QString buildWhere(
 
     QStringList fragments;
     foreach (const QContactFilter &filter, filters) {
-        const QString fragment = buildWhere(filter, db, table, detailType, bindings, failed, transientModifiedRequired, globalPresenceRequired);
+        const QString fragment = buildWhere(filter, db, table, detailType, bindings, failed,
+                                            transientModifiedRequired, globalPresenceRequired);
         if (filter.type() != QContactFilter::DefaultFilter && !*failed) {
             // default filter gets special (permissive) treatment by the intersection filter.
             fragments.append(fragment.isEmpty() ? QStringLiteral("NULL") : fragment);
@@ -1599,8 +1609,9 @@ static QString buildWhere(
     return fragments.join(QStringLiteral(" AND "));
 }
 
-static QString buildContactWhere(const QContactFilter &filter, ContactsDatabase &db, const QString &table, QContactDetail::DetailType detailType, QVariantList *bindings,
-                          bool *failed, bool *transientModifiedRequired, bool *globalPresenceRequired)
+static QString buildContactWhere(const QContactFilter &filter, ContactsDatabase &db, const QString &table,
+                                 QContactDetail::DetailType detailType, QVariantList *bindings,
+                                 bool *failed, bool *transientModifiedRequired, bool *globalPresenceRequired)
 {
     Q_ASSERT(failed);
     Q_ASSERT(globalPresenceRequired);
@@ -1610,7 +1621,8 @@ static QString buildContactWhere(const QContactFilter &filter, ContactsDatabase 
     case QContactFilter::DefaultFilter:
         return QString();
     case QContactFilter::ContactDetailFilter:
-        return buildWhere(static_cast<const QContactDetailFilter &>(filter), true, bindings, failed, transientModifiedRequired, globalPresenceRequired);
+        return buildWhere(static_cast<const QContactDetailFilter &>(filter), true, bindings, failed,
+                          transientModifiedRequired, globalPresenceRequired);
     case QContactFilter::ContactDetailRangeFilter:
         return buildWhere(static_cast<const QContactDetailRangeFilter &>(filter), true, bindings, failed);
     case QContactFilter::ChangeLogFilter:
@@ -1618,9 +1630,11 @@ static QString buildContactWhere(const QContactFilter &filter, ContactsDatabase 
     case QContactFilter::RelationshipFilter:
         return buildWhere(static_cast<const QContactRelationshipFilter &>(filter), bindings, failed);
     case QContactFilter::IntersectionFilter:
-        return buildWhere(buildContactWhere, static_cast<const QContactIntersectionFilter &>(filter), db, table, detailType, bindings, failed, transientModifiedRequired, globalPresenceRequired);
+        return buildWhere(buildContactWhere, static_cast<const QContactIntersectionFilter &>(filter), db, table,
+                          detailType, bindings, failed, transientModifiedRequired, globalPresenceRequired);
     case QContactFilter::UnionFilter:
-        return buildWhere(buildContactWhere, static_cast<const QContactUnionFilter &>(filter), db, table, detailType, bindings, failed, transientModifiedRequired, globalPresenceRequired);
+        return buildWhere(buildContactWhere, static_cast<const QContactUnionFilter &>(filter), db, table, detailType,
+                          bindings, failed, transientModifiedRequired, globalPresenceRequired);
     case QContactFilter::IdFilter:
         return buildWhere(static_cast<const QContactIdFilter &>(filter), db, table, bindings, failed);
     case QContactFilter::CollectionFilter:
@@ -2245,10 +2259,10 @@ QContactManager::Error ContactReader::fetchContacts(const QContactCollectionId &
     // we can save some memory by only fetching added/modified/deleted contacts.
     const QContactFilter filter = unmodifiedContacts
                                 ? (collectionFilter
-                                  |deletedContactsFilter)
+                                   | deletedContactsFilter)
                                 : (addedContactsFilter
-                                  |modifiedContactsFilter
-                                  |deletedContactsFilter);
+                                   | modifiedContactsFilter
+                                   | deletedContactsFilter);
 
     const bool keepChangeFlags = true;
 
@@ -2305,7 +2319,8 @@ QContactManager::Error ContactReader::readContacts(
 
     bool whereFailed = false;
     QVariantList bindings;
-    QString where = buildContactWhere(filter, m_database, table, QContactDetail::TypeUndefined, &bindings, &whereFailed, &transientModifiedRequired, &globalPresenceRequired);
+    QString where = buildContactWhere(filter, m_database, table, QContactDetail::TypeUndefined, &bindings, &whereFailed,
+                                      &transientModifiedRequired, &globalPresenceRequired);
     if (whereFailed) {
         QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create WHERE expression: invalid filter specification"));
         return QContactManager::UnspecifiedError;
@@ -2931,7 +2946,8 @@ QContactManager::Error ContactReader::readContactIds(
 
     bool failed = false;
     QVariantList bindings;
-    QString where = buildContactWhere(filter, m_database, tableName, QContactDetail::TypeUndefined, &bindings, &failed, &transientModifiedRequired, &globalPresenceRequired);
+    QString where = buildContactWhere(filter, m_database, tableName, QContactDetail::TypeUndefined, &bindings,
+                                      &failed, &transientModifiedRequired, &globalPresenceRequired);
     if (failed) {
         QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create WHERE expression: invalid filter specification"));
         return QContactManager::UnspecifiedError;

--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -3771,7 +3771,8 @@ static bool promoteDetailType(QContactDetail::DetailType type, const ContactWrit
     Note that QContactSyncTarget and QContactGuid details will NOT be promoted,
     nor will QContactDisplayLabel or QContactType details.
 */
-static void promoteDetailsToAggregate(const QContact &contact, QContact *aggregate, const ContactWriter::DetailList &definitionMask, bool forcePromotion)
+static void promoteDetailsToAggregate(const QContact &contact, QContact *aggregate,
+                                      const ContactWriter::DetailList &definitionMask, bool forcePromotion)
 {
     foreach (const QContactDetail &original, contact.details()) {
         if (!promoteDetailType(original.type(), definitionMask, forcePromotion)) {

--- a/src/engine/semaphore_p.cpp
+++ b/src/engine/semaphore_p.cpp
@@ -30,7 +30,6 @@
  */
 
 #include "semaphore_p.h"
-#include "trace_p.h"
 
 #include <errno.h>
 #include <unistd.h>
@@ -54,7 +53,7 @@ union semun {
 
 void semaphoreError(const char *msg, const char *id, int error)
 {
-    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("%1 %2: %3 (%4)").arg(msg).arg(id).arg(::strerror(error)).arg(error));
+    qWarning() << QString::fromLatin1("%1 %2: %3 (%4)").arg(msg).arg(id).arg(::strerror(error)).arg(error);
 }
 
 int semaphoreInit(const char *id, size_t count, const int *initialValues)

--- a/src/extensions/contactdelta_impl.h
+++ b/src/extensions/contactdelta_impl.h
@@ -122,7 +122,6 @@ void removeDatabaseIdsFromList(QList<QContactDetail> *dets)
     }
 }
 
-
 void dumpContactDetail(const QContactDetail &d)
 {
     qWarning() << "++ ---------" << d.type();

--- a/src/extensions/qtcontacts-extensions.h
+++ b/src/extensions/qtcontacts-extensions.h
@@ -49,13 +49,13 @@
 QT_BEGIN_NAMESPACE_CONTACTS
 
 // In QContactDetail, we support some extra fields
-static const int QContactDetail__FieldModifiable = (QContactDetail::FieldLinkedDetailUris+2);
-static const int QContactDetail__FieldNonexportable = (QContactDetail::FieldLinkedDetailUris+3);
-static const int QContactDetail__FieldChangeFlags = (QContactDetail::FieldLinkedDetailUris+4);
-static const int QContactDetail__FieldUnhandledChangeFlags = (QContactDetail::FieldLinkedDetailUris+5);
-static const int QContactDetail__FieldDatabaseId = (QContactDetail::FieldLinkedDetailUris+6);
-static const int QContactDetail__FieldCreated = (QContactDetail::FieldLinkedDetailUris+7);
-static const int QContactDetail__FieldModified = (QContactDetail::FieldLinkedDetailUris+8);
+static const int QContactDetail__FieldModifiable = (QContactDetail::FieldLinkedDetailUris + 2);
+static const int QContactDetail__FieldNonexportable = (QContactDetail::FieldLinkedDetailUris + 3);
+static const int QContactDetail__FieldChangeFlags = (QContactDetail::FieldLinkedDetailUris + 4);
+static const int QContactDetail__FieldUnhandledChangeFlags = (QContactDetail::FieldLinkedDetailUris + 5);
+static const int QContactDetail__FieldDatabaseId = (QContactDetail::FieldLinkedDetailUris + 6);
+static const int QContactDetail__FieldCreated = (QContactDetail::FieldLinkedDetailUris + 7);
+static const int QContactDetail__FieldModified = (QContactDetail::FieldLinkedDetailUris + 8);
 
 // The following change types can be reported for a detail when fetched via the synchronization plugin fetch API.
 static const int QContactDetail__ChangeFlag_IsAdded    = 1 << 0;
@@ -70,11 +70,11 @@ static const int QContactDisplayLabel__FieldLabelGroupSortOrder = (QContactDispl
 //   AccountPath - identifying path value for the account
 //   AccountIconPath - path to an icon indicating the service type of the account
 //   Enabled - a boolean indicating whether or not the account is enabled for activity
-static const int QContactOnlineAccount__FieldAccountPath = (QContactOnlineAccount::FieldSubTypes+1);
-static const int QContactOnlineAccount__FieldAccountIconPath = (QContactOnlineAccount::FieldSubTypes+2);
-static const int QContactOnlineAccount__FieldEnabled = (QContactOnlineAccount::FieldSubTypes+3);
-static const int QContactOnlineAccount__FieldAccountDisplayName = (QContactOnlineAccount::FieldSubTypes+4);
-static const int QContactOnlineAccount__FieldServiceProviderDisplayName = (QContactOnlineAccount::FieldSubTypes+5);
+static const int QContactOnlineAccount__FieldAccountPath = (QContactOnlineAccount::FieldSubTypes + 1);
+static const int QContactOnlineAccount__FieldAccountIconPath = (QContactOnlineAccount::FieldSubTypes + 2);
+static const int QContactOnlineAccount__FieldEnabled = (QContactOnlineAccount::FieldSubTypes + 3);
+static const int QContactOnlineAccount__FieldAccountDisplayName = (QContactOnlineAccount::FieldSubTypes + 4);
+static const int QContactOnlineAccount__FieldServiceProviderDisplayName = (QContactOnlineAccount::FieldSubTypes + 5);
 
 // We support the QContactOriginMetadata detail type
 static const QContactDetail::DetailType QContactDetail__TypeOriginMetadata = static_cast<QContactDetail::DetailType>(QContactDetail::TypeVersion + 1);

--- a/src/extensions/twowaycontactsyncadaptor.h
+++ b/src/extensions/twowaycontactsyncadaptor.h
@@ -50,6 +50,7 @@ QTCONTACTS_USE_NAMESPACE
 
 namespace QtContactsSqliteExtensions {
 class TwoWayContactSyncAdaptorPrivate;
+
 class TwoWayContactSyncAdaptor
 {
 public:

--- a/src/extensions/twowaycontactsyncadaptor_impl.h
+++ b/src/extensions/twowaycontactsyncadaptor_impl.h
@@ -278,6 +278,8 @@ void modifyContactDetail(const QContactDetail &original, const QContactDetail &m
 
 void removeEquivalentDetails(QList<QContactDetail> &original, QList<QContactDetail> &updated, QList<QContact> &equivalent)
 {
+    Q_UNUSED(equivalent);
+
     // Determine which details are in the update contact which aren't in the database contact:
     // Detail order is not defined, so loop over the entire set for each, removing matches or
     // superset details (eg, backend added a field (like lastModified to timestamp) on previous save)
@@ -459,6 +461,11 @@ bool TwoWayContactSyncAdaptor::determineRemoteCollectionChanges(
         const QList<QContactCollection> &locallyUnmodifiedCollections,
         QContactManager::Error *error)
 {
+    Q_UNUSED(locallyAddedCollections);
+    Q_UNUSED(locallyModifiedCollections);
+    Q_UNUSED(locallyRemovedCollections);
+    Q_UNUSED(locallyUnmodifiedCollections);
+
     // By default, we assume that the plugin is unable to determine
     // a precise delta of what collection metadata has changed on
     // the remote server.
@@ -796,6 +803,8 @@ void TwoWayContactSyncAdaptor::startCollectionSync(const QContactCollection &col
 
 bool TwoWayContactSyncAdaptor::deleteRemoteCollection(const QContactCollection &collection)
 {
+    Q_UNUSED(collection);
+
     // The plugin must implement this method to delete
     // a remote addressbook from the server,
     // and then invoke remoteCollectionDeleted() when complete
@@ -821,6 +830,8 @@ void TwoWayContactSyncAdaptor::remoteCollectionDeleted(const QContactCollection 
 
 bool TwoWayContactSyncAdaptor::determineRemoteContacts(const QContactCollection &collection)
 {
+    Q_UNUSED(collection);
+
     // The plugin must implement this method to retrieve
     // information about contacts in an addressbook on the remote server,
     // and call remoteContactsDetermined() once complete
@@ -993,6 +1004,12 @@ bool TwoWayContactSyncAdaptor::determineRemoteContactChanges(
         const QList<QContact> &localUnmodifiedContacts,
         QContactManager::Error *error)
 {
+    Q_UNUSED(collection);
+    Q_UNUSED(localAddedContacts);
+    Q_UNUSED(localModifiedContacts);
+    Q_UNUSED(localDeletedContacts);
+    Q_UNUSED(localUnmodifiedContacts);
+
     // By default, we assume that the plugin is unable to determine
     // a precise delta of what contacts have changed on
     // the remote server.
@@ -1141,6 +1158,11 @@ bool TwoWayContactSyncAdaptor::storeLocalChangesRemotely(
         const QList<QContact> &modifiedContacts,
         const QList<QContact> &deletedContacts)
 {
+    Q_UNUSED(collection);
+    Q_UNUSED(addedContacts);
+    Q_UNUSED(modifiedContacts);
+    Q_UNUSED(deletedContacts);
+
     // The plugin must implement this method to store
     // information about contacts to an addressbook on the remote server,
     // and then call localChangesStoredRemotely() once complete

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -1171,13 +1171,16 @@ void tst_Aggregation::updateAggregateOfLocalAndSync()
     // now ensure that any attempt to modify the aggregate directly will fail.
     QCOMPARE(aggregateAlice.details<QContactPhoneNumber>().size(), 1); // comes from the local contact
     QContactPhoneNumber maph = aggregateAlice.detail<QContactPhoneNumber>();
-    QVERIFY((maph.accessConstraints() & QContactDetail::Irremovable) && (maph.accessConstraints() & QContactDetail::ReadOnly));
+    QVERIFY((maph.accessConstraints() & QContactDetail::Irremovable)
+            && (maph.accessConstraints() & QContactDetail::ReadOnly));
     maph.setNumber("11115");
     QVERIFY(!aggregateAlice.saveDetail(&maph));
 
-    QCOMPARE(aggregateAlice.details<QContactEmailAddress>().size(), 1); // there are two, but since the values were identical, should only have one!
+    // there are two, but since the values were identical, should only have one!
+    QCOMPARE(aggregateAlice.details<QContactEmailAddress>().size(), 1);
     QContactEmailAddress mem = aggregateAlice.detail<QContactEmailAddress>();
-    QVERIFY((mem.accessConstraints() & QContactDetail::Irremovable) && (mem.accessConstraints() & QContactDetail::ReadOnly));
+    QVERIFY((mem.accessConstraints() & QContactDetail::Irremovable)
+            && (mem.accessConstraints() & QContactDetail::ReadOnly));
     mem.setEmailAddress("aliceP2@test.com");
     QVERIFY(!aggregateAlice.saveDetail(&mem));
 
@@ -1201,15 +1204,21 @@ void tst_Aggregation::updateAggregateOfLocalAndSync()
     QCOMPARE(aggregateAlice.details<QContactNickname>().size(), 1);     // comes from the local contact
     QVERIFY(!detailProvenance(aggregateAlice.detail<QContactNickname>()).isEmpty());
     QCOMPARE(aggregateAlice.details<QContactPhoneNumber>().size(), 1);  // comes from the local contact
-    QCOMPARE(detailProvenanceContact(aggregateAlice.detail<QContactPhoneNumber>()), detailProvenanceContact(aggregateAlice.detail<QContactNickname>()));
-    QCOMPARE(aggregateAlice.detail<QContactPhoneNumber>().value<QString>(QContactPhoneNumber::FieldNumber), QString::fromLatin1("11111"));
+    QCOMPARE(detailProvenanceContact(aggregateAlice.detail<QContactPhoneNumber>()),
+             detailProvenanceContact(aggregateAlice.detail<QContactNickname>()));
+    QCOMPARE(aggregateAlice.detail<QContactPhoneNumber>().value<QString>(QContactPhoneNumber::FieldNumber),
+             QString::fromLatin1("11111"));
     QCOMPARE(aggregateAlice.details<QContactHobby>().size(), 1);        // comes from the sync contact
     QVERIFY(!detailProvenance(aggregateAlice.detail<QContactHobby>()).isEmpty());
-    QCOMPARE(aggregateAlice.detail<QContactHobby>().value<QString>(QContactHobby::FieldHobby), QString::fromLatin1("tennis"));
+    QCOMPARE(aggregateAlice.detail<QContactHobby>().value<QString>(QContactHobby::FieldHobby),
+             QString::fromLatin1("tennis"));
     QCOMPARE(aggregateAlice.details<QContactNote>().size(), 1);         // comes from the sync contact
-    QCOMPARE(detailProvenanceContact(aggregateAlice.detail<QContactNote>()), detailProvenanceContact(aggregateAlice.detail<QContactHobby>()));
-    QVERIFY(detailProvenanceContact(aggregateAlice.detail<QContactNote>()) != detailProvenanceContact(aggregateAlice.detail<QContactNickname>()));
-    QCOMPARE(aggregateAlice.detail<QContactNote>().value<QString>(QContactNote::FieldNote), QString::fromLatin1("noteworthy note"));
+    QCOMPARE(detailProvenanceContact(aggregateAlice.detail<QContactNote>()),
+             detailProvenanceContact(aggregateAlice.detail<QContactHobby>()));
+    QVERIFY(detailProvenanceContact(aggregateAlice.detail<QContactNote>())
+            != detailProvenanceContact(aggregateAlice.detail<QContactNickname>()));
+    QCOMPARE(aggregateAlice.detail<QContactNote>().value<QString>(QContactNote::FieldNote),
+             QString::fromLatin1("noteworthy note"));
 
     QList<QContactEmailAddress> aaems = aggregateAlice.details<QContactEmailAddress>();
     QCOMPARE(aaems.size(), 1); // values should be unchanged (and identical).
@@ -1354,7 +1363,8 @@ void tst_Aggregation::updateAggregateOfLocalAndModifiableSync()
     QVERIFY(detailProvenanceContact(aggregateAlice.details<QContactEmailAddress>().at(0)) != localContact);
     QVERIFY(!detailProvenance(aggregateAlice.details<QContactEmailAddress>().at(1)).isEmpty());
     QVERIFY(detailProvenanceContact(aggregateAlice.details<QContactEmailAddress>().at(1)) != localContact);
-    QVERIFY(detailProvenanceContact(aggregateAlice.details<QContactEmailAddress>().at(0)) != detailProvenanceContact(aggregateAlice.details<QContactEmailAddress>().at(1)));
+    QVERIFY(detailProvenanceContact(aggregateAlice.details<QContactEmailAddress>().at(0))
+            != detailProvenanceContact(aggregateAlice.details<QContactEmailAddress>().at(1)));
 
     QCOMPARE(aggregateAlice.details<QContactNote>().size(), 1);
     QCOMPARE(detailProvenanceContact(aggregateAlice.detail<QContactNote>()), teabContact);
@@ -1578,7 +1588,8 @@ void tst_Aggregation::compositionPrefersLocal()
     QContactStatusFlags flags;
     flags.setFlag(QContactStatusFlags::IsAdded, true);
     abContact3.saveDetail(&flags, QContact::IgnoreAccessConstraints);
-    QtContactsSqliteExtensions::ContactManagerEngine::ConflictResolutionPolicy policy(QtContactsSqliteExtensions::ContactManagerEngine::PreserveLocalChanges);
+    QtContactsSqliteExtensions::ContactManagerEngine::ConflictResolutionPolicy
+            policy(QtContactsSqliteExtensions::ContactManagerEngine::PreserveLocalChanges);
     QContactManager::Error err;
     QHash<QContactCollection*, QList<QContact> *> additions;
     QHash<QContactCollection*, QList<QContact> *> modifications;
@@ -1595,7 +1606,8 @@ void tst_Aggregation::compositionPrefersLocal()
     QContact abc1, abc2, abc3, l, a; // addressbook contacts 1,2,3, local, aggregate.
     foreach (const QContact &curr, allContacts) {
         QContactName currName = curr.detail<QContactName>();
-        if (currName.firstName() == QLatin1String("Link") && currName.lastName() == QLatin1String("CompositionTester")) {
+        if (currName.firstName() == QLatin1String("Link")
+                && currName.lastName() == QLatin1String("CompositionTester")) {
             if (curr.collectionId() == testCollection1.id()) {
                 abc1 = curr;
             } else if (curr.collectionId() == testCollection2.id()) {
@@ -1849,7 +1861,8 @@ void tst_Aggregation::uniquenessConstraints()
     testsyncAlice.saveDetail(&tsast);
     QVERIFY(m_cm->saveContact(&testsyncAlice)); // should get aggregated into aggregateAlice.
     aggregateAlice = m_cm->contact(retrievalId(aggregateAlice)); // reload
-    QCOMPARE(aggregateAlice.details<QContactBirthday>().size(), 1); // should still only have one birthday - local should take precedence.
+    // should still only have one birthday - local should take precedence.
+    QCOMPARE(aggregateAlice.details<QContactBirthday>().size(), 1);
     QCOMPARE(aggregateAlice.detail<QContactBirthday>().date(), aliceBirthday.date());
     QCOMPARE(aggregateAlice.detail<QContactNote>().note(), tsanote.note());
     aggregateAlice = m_cm->contact(retrievalId(aggregateAlice));
@@ -2276,14 +2289,16 @@ void tst_Aggregation::alterRelationships()
     QCOMPARE(allContacts.size(), allCount); // should return as many contacts as contactIds.
     foreach (const QContact &curr, allContacts) {
         QContactName currName = curr.detail<QContactName>();
-        if (currName.middleName() == QLatin1String("Alice") && currName.lastName() == QLatin1String("alterRelationships")) {
+        if (currName.middleName() == QLatin1String("Alice")
+                && currName.lastName() == QLatin1String("alterRelationships")) {
             if (curr.collectionId() == testAddressbook.id()) {
                 localAlice = curr;
             } else {
                 QCOMPARE(curr.collectionId().localId(), aggregateAddressbookId());
                 aggregateAlice = curr;
             }
-        } else if (currName.middleName() == QLatin1String("Bob") && currName.lastName() == QLatin1String("alterRelationships")) {
+        } else if (currName.middleName() == QLatin1String("Bob")
+                   && currName.lastName() == QLatin1String("alterRelationships")) {
             if (curr.collectionId() == trialAddressbook.id()) {
                 localBob = curr;
             } else {
@@ -2329,14 +2344,16 @@ void tst_Aggregation::alterRelationships()
     allContacts = m_cm->contacts(allCollections);
     foreach (const QContact &curr, allContacts) {
         QContactName currName = curr.detail<QContactName>();
-        if (currName.middleName() == QLatin1String("Alice") && currName.lastName() == QLatin1String("alterRelationships")) {
+        if (currName.middleName() == QLatin1String("Alice")
+                && currName.lastName() == QLatin1String("alterRelationships")) {
             if (curr.collectionId() == testAddressbook.id()) {
                 localAlice = curr;
             } else {
                 QCOMPARE(curr.collectionId().localId(), aggregateAddressbookId());
                 aggregateAlice = curr;
             }
-        } else if (currName.middleName() == QLatin1String("Bob") && currName.lastName() == QLatin1String("alterRelationships")) {
+        } else if (currName.middleName() == QLatin1String("Bob")
+                   && currName.lastName() == QLatin1String("alterRelationships")) {
             if (curr.collectionId() == trialAddressbook.id()) {
                 localBob = curr;
             } else {
@@ -2384,14 +2401,16 @@ void tst_Aggregation::alterRelationships()
     allContacts = m_cm->contacts(allCollections);
     foreach (const QContact &curr, allContacts) {
         QContactName currName = curr.detail<QContactName>();
-        if (currName.middleName() == QLatin1String("Alice") && currName.lastName() == QLatin1String("alterRelationships")) {
+        if (currName.middleName() == QLatin1String("Alice")
+                && currName.lastName() == QLatin1String("alterRelationships")) {
             if (curr.collectionId() == testAddressbook.id()) {
                 localAlice = curr;
             } else {
                 QCOMPARE(curr.collectionId().localId(), aggregateAddressbookId());
                 aggregateAlice = curr;
             }
-        } else if (currName.middleName() == QLatin1String("Bob") && currName.lastName() == QLatin1String("alterRelationships")) {
+        } else if (currName.middleName() == QLatin1String("Bob")
+                   && currName.lastName() == QLatin1String("alterRelationships")) {
             if (curr.collectionId() == trialAddressbook.id()) {
                 localBob = curr;
             } else {
@@ -2525,28 +2544,32 @@ void tst_Aggregation::alterRelationships()
     allContacts = m_cm->contacts(allCollections);
     foreach (const QContact &curr, allContacts) {
         QContactName currName = curr.detail<QContactName>();
-        if (currName.middleName() == QLatin1String("Alice") && currName.lastName() == QLatin1String("alterRelationships")) {
+        if (currName.middleName() == QLatin1String("Alice")
+                && currName.lastName() == QLatin1String("alterRelationships")) {
             if (curr.collectionId() == testAddressbook.id()) {
                 localAlice = curr;
             } else {
                 QCOMPARE(curr.collectionId().localId(), aggregateAddressbookId());
                 aggregateAlice = curr;
             }
-        } else if (currName.middleName() == QLatin1String("Bob") && currName.lastName() == QLatin1String("alterRelationships")) {
+        } else if (currName.middleName() == QLatin1String("Bob")
+                   && currName.lastName() == QLatin1String("alterRelationships")) {
             if (curr.collectionId() == trialAddressbook.id()) {
                 localBob = curr;
             } else {
                 QCOMPARE(curr.collectionId().localId(), aggregateAddressbookId());
                 aggregateBob = curr;
             }
-        } else if (currName.middleName() == QLatin1String("Edmond") && currName.lastName() == QLatin1String("alterRelationshipsLocal")) {
+        } else if (currName.middleName() == QLatin1String("Edmond")
+                   && currName.lastName() == QLatin1String("alterRelationshipsLocal")) {
             if (curr.collectionId().localId() == localAddressbookId()) {
                 localEdmond = curr;
             } else {
                 QCOMPARE(curr.collectionId().localId(), aggregateAddressbookId());
                 aggregateEdmond = curr;
             }
-        } else if (currName.middleName() == QLatin1String("Fred") && currName.lastName() == QLatin1String("alterRelationshipsLocal")) {
+        } else if (currName.middleName() == QLatin1String("Fred")
+                   && currName.lastName() == QLatin1String("alterRelationshipsLocal")) {
             if (curr.collectionId().localId() == localAddressbookId()) {
                 localFred = curr;
             } else {
@@ -3030,16 +3053,19 @@ void tst_Aggregation::regenerateAggregate()
                 && currPhn.number() == QLatin1String("88888")
                 && currEm.emailAddress() == QLatin1String("alice8@test.com")) {
             if (curr.collectionId().localId() == localAddressbookId()) {
-                QCOMPARE(curr.detail<QContactHobby>().value<QString>(QContactHobby::FieldHobby), QString()); // local shouldn't get it
+                // local shouldn't get it
+                QCOMPARE(curr.detail<QContactHobby>().value<QString>(QContactHobby::FieldHobby), QString());
                 localAlice = curr;
                 foundLocalAlice = true;
             } else if (curr.collectionId() == testAddressbook.id()) {
-                QCOMPARE(curr.detail<QContactHobby>().value<QString>(QContactHobby::FieldHobby), QLatin1String("tennis")); // came from here
+                // came from here
+                QCOMPARE(curr.detail<QContactHobby>().value<QString>(QContactHobby::FieldHobby), QLatin1String("tennis"));
                 testAlice = curr;
                 foundTestAlice = true;
             } else {
                 QCOMPARE(curr.collectionId().localId(), aggregateAddressbookId());
-                QCOMPARE(curr.detail<QContactHobby>().value<QString>(QContactHobby::FieldHobby), QLatin1String("tennis")); // aggregated to here
+                // aggregated to here
+                QCOMPARE(curr.detail<QContactHobby>().value<QString>(QContactHobby::FieldHobby), QLatin1String("tennis"));
                 aggregateAlice = curr;
                 foundAggregateAlice = true;
             }

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -1161,7 +1161,7 @@ void tst_Aggregation::updateAggregateOfLocalAndSync()
 
     // now grab the aggregate alice
     QContactRelationshipFilter aggf;
-    setFilterContactId(aggf, alice.id());
+    aggf.setRelatedContactId(alice.id());
     aggf.setRelatedContactRole(QContactRelationship::Second);
     setFilterType(aggf, QContactRelationship::Aggregates);
     QList<QContact> allAggregatesOfAlice = m_cm->contacts(aggf);
@@ -1333,7 +1333,7 @@ void tst_Aggregation::updateAggregateOfLocalAndModifiableSync()
     QContact aggregateAlice;
     {
         QContactRelationshipFilter filter;
-        setFilterContactId(filter, alice.id());
+        filter.setRelatedContactId(alice.id());
         filter.setRelatedContactRole(QContactRelationship::Second);
         setFilterType(filter, QContactRelationship::Aggregates);
         QList<QContact> allAggregatesOfAlice = m_cm->contacts(filter);

--- a/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
+++ b/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
@@ -861,7 +861,7 @@ void tst_QContactManager::add()
 
     QVERIFY(!alice.id().managerUri().isEmpty());
     QVERIFY(ContactId::isValid(alice.id()));
-    QCOMPARE(cm->contactIds().count(), currCount+1);
+    QCOMPARE(cm->contactIds().count(), currCount + 1);
 
     // Test that the ID is roundtripped via string correctly
     QCOMPARE(QContactId::fromString(alice.id().toString()), alice.id());

--- a/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
+++ b/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
@@ -4798,7 +4798,7 @@ void tst_QContactManager::constituentOfSelf()
     // Find the aggregate contact created by saving
     QContactRelationshipFilter relationshipFilter;
     setFilterType(relationshipFilter, QContactRelationship::Aggregates);
-    setFilterContactId(relationshipFilter, constituent.id());
+    relationshipFilter.setRelatedContactId(constituent.id());
     relationshipFilter.setRelatedContactRole(QContactRelationship::Second);
 
     // Now connect our contact to the real self contact

--- a/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
+++ b/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
@@ -52,6 +52,7 @@
 
 #include "../../util.h"
 #include "../../qcontactmanagerdataholder.h"
+#include "qtcontacts-extensions.h"
 
 #define SQLITE_MANAGER "org.nemomobile.contacts.sqlite"
 
@@ -127,6 +128,10 @@ static bool detailValuesSuperset(const QContactDetail &lhs, const QContactDetail
     }
 
     foreach (const DetailMap::key_type &key, rhsValues.keys()) {
+        // not caring about timestamp differences
+        if (key == QContactDetail__FieldCreated || key == QContactDetail__FieldModified) {
+            continue;
+        }
         if (!variantEqual(lhsValues[key], rhsValues[key])) {
             return false;
         }
@@ -1072,7 +1077,13 @@ void tst_QContactManager::update()
     alice = cm->contact(retrievalId(alice)); // force reload of (persisted) alice
     QContact updated = cm->contact(retrievalId(alice));
     QContactName updatedName = updated.detail<QContactName>();
-    QCOMPARE(updatedName, name);
+    QCOMPARE(updatedName.prefix(), name.prefix());
+    QCOMPARE(updatedName.firstName(), name.firstName());
+    QCOMPARE(updatedName.middleName(), name.middleName());
+    QCOMPARE(updatedName.lastName(), name.lastName());
+    QCOMPARE(updatedName.suffix(), name.suffix());
+    QCOMPARE(updatedName.customLabel(), name.customLabel());
+
     QCOMPARE(cm->contacts().size(), contactCount); // contact count should be the same, no new contacts
 
     QContactStatusFlags flags = updated.detail<QContactStatusFlags>();

--- a/tests/auto/synctransactions/testsyncadaptor.cpp
+++ b/tests/auto/synctransactions/testsyncadaptor.cpp
@@ -48,13 +48,6 @@
 
 namespace {
 
-QMap<QString, QString> managerParameters() {
-    QMap<QString, QString> params;
-    params.insert(QStringLiteral("autoTest"), QStringLiteral("true"));
-    params.insert(QStringLiteral("mergePresenceChanges"), QStringLiteral("true"));
-    return params;
-}
-
 QContact updateContactEtag(const QContact &c)
 {
     const QList<QContactExtendedDetail> extendedDetails = c.details<QContactExtendedDetail>();

--- a/tests/util.h
+++ b/tests/util.h
@@ -229,11 +229,6 @@ void setFilterType(QContactRelationshipFilter &filter, T type)
     filter.setRelationshipType(relationshipString(type));
 }
 
-void setFilterContactId(QContactRelationshipFilter &filter, const QContactId &contactId)
-{
-    filter.setRelatedContactId(contactId);
-}
-
 QContactRelationship makeRelationship(const QContactId &firstId, const QContactId &secondId)
 {
     QContactRelationship relationship;


### PR DESCRIPTION
Started here by checking the failed unit tests but then ended up fixing other things, including renaming the extension header package with -devel, and avoiding exposing some internal details with the installed headers. 

Individual things in their own commits.

The unit test failures were interesting, from commit message:

    0.3.11 / commit 6527885d8679 added timestamps to contact details
    in order to know the latest changed avatar. That had a side-effect
    of messing with QContactDetail comparisons due to timestamp differences
    and broke some unit tests.
    
    The change is slightly suspicious due to ending up affecting the
    comparisons, and it's somewhat vague should that be taken into account
    when doing it, but as the comparison is implemented in qtpim and
    the timestamps are just extra fields here, it may not be that easy to
    change.
    
    Thus just adjusting the unit test specific expectations for now,
    that should fine regardless of how QContactDetail::operator==() works.
    
    tst_aggregation still failing, not yet sure what we should do there.

For the aggregation case, it's having now two email details on the unit test, but at least trying locally linking two contacts with a same email address I'm not getting duplicate entries on the contact card. Leaving that case now for further consideration.