### PR TITLE
Chase deprecations until Qt 5.15 and prepare for Qt6

### DIFF
--- a/src/engine/contactnotifier.cpp
+++ b/src/engine/contactnotifier.cpp
@@ -196,7 +196,7 @@ void ContactNotifier::relationshipsAdded(const QSet<QContactId> &contactIds)
 {
     if (!contactIds.isEmpty()) {
         QDBusMessage message = createSignal("relationshipsAdded", m_nonprivileged);
-        message.setArguments(QVariantList() << QVariant::fromValue(idVector(contactIds.toList())));
+        message.setArguments(QVariantList() << QVariant::fromValue(idVector(contactIds.values())));
         sendMessage(message);
     }
 }
@@ -205,7 +205,7 @@ void ContactNotifier::relationshipsRemoved(const QSet<QContactId> &contactIds)
 {
     if (!contactIds.isEmpty()) {
         QDBusMessage message = createSignal("relationshipsRemoved", m_nonprivileged);
-        message.setArguments(QVariantList() << QVariant::fromValue(idVector(contactIds.toList())));
+        message.setArguments(QVariantList() << QVariant::fromValue(idVector(contactIds.values())));
         sendMessage(message);
     }
 }

--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -134,7 +134,7 @@ static QVariant stringListValue(const QVariant &columnValue)
         return columnValue;
 
     QString listString(columnValue.toString());
-    return listString.split(QLatin1Char(';'), QString::SkipEmptyParts);
+    return listString.split(QLatin1Char(';'), Qt::SkipEmptyParts);
 }
 
 static QVariant urlValue(const QVariant &columnValue)
@@ -204,7 +204,7 @@ static void setValues(QContactAddress *detail, QSqlQuery *query, const int offse
     setValue(detail, T::FieldLocality     , query->value(offset + 3));
     setValue(detail, T::FieldPostcode     , query->value(offset + 4));
     setValue(detail, T::FieldCountry      , query->value(offset + 5));
-    const QStringList subTypeValues(query->value(offset + 6).toString().split(QLatin1Char(';'), QString::SkipEmptyParts));
+    const QStringList subTypeValues(query->value(offset + 6).toString().split(QLatin1Char(';'), Qt::SkipEmptyParts));
     setValue(detail, T::FieldSubTypes     , QVariant::fromValue<QList<int> >(subTypeList(subTypeValues)));
 }
 
@@ -305,7 +305,7 @@ static void setValues(QContactFamily *detail, QSqlQuery *query, const int offset
     typedef QContactFamily T;
 
     setValue(detail, T::FieldSpouse  , query->value(offset + 0));
-    setValue(detail, T::FieldChildren, query->value(offset + 1).toString().split(QLatin1Char(';'), QString::SkipEmptyParts));
+    setValue(detail, T::FieldChildren, query->value(offset + 1).toString().split(QLatin1Char(';'), Qt::SkipEmptyParts));
 }
 
 static const FieldInfo favoriteFields[] =
@@ -462,7 +462,7 @@ static void setValues(QContactOnlineAccount *detail, QSqlQuery *query, const int
     setValue(detail, T::FieldServiceProvider, query->value(offset + 3));
     setValue(detail, T::FieldCapabilities   , stringListValue(query->value(offset + 4)));
 
-    const QStringList subTypeValues(query->value(offset + 5).toString().split(QLatin1Char(';'), QString::SkipEmptyParts));
+    const QStringList subTypeValues(query->value(offset + 5).toString().split(QLatin1Char(';'), Qt::SkipEmptyParts));
     setValue(detail, T::FieldSubTypes, QVariant::fromValue<QList<int> >(subTypeList(subTypeValues)));
 
     setValue(detail, QContactOnlineAccount__FieldAccountPath,                query->value(offset + 6));
@@ -509,7 +509,7 @@ static void setValues(QContactPhoneNumber *detail, QSqlQuery *query, const int o
 
     setValue(detail, T::FieldNumber  , query->value(offset + 0));
 
-    const QStringList subTypeValues(query->value(offset + 1).toString().split(QLatin1Char(';'), QString::SkipEmptyParts));
+    const QStringList subTypeValues(query->value(offset + 1).toString().split(QLatin1Char(';'), Qt::SkipEmptyParts));
     setValue(detail, T::FieldSubTypes, QVariant::fromValue<QList<int> >(subTypeList(subTypeValues)));
 
     setValue(detail, QContactPhoneNumber::FieldNormalizedNumber, query->value(offset + 2));
@@ -710,11 +710,11 @@ static void readDetail(QContact *contact, QSqlQuery &query, quint32 contactId, q
     if (!linkedDetailUrisValue.isEmpty()) {
         setValue(&detail,
                  QContactDetail::FieldLinkedDetailUris,
-                 linkedDetailUrisValue.split(QLatin1Char(';'), QString::SkipEmptyParts));
+                 linkedDetailUrisValue.split(QLatin1Char(';'), Qt::SkipEmptyParts));
     }
     if (!contextValue.isEmpty()) {
         QList<int> contexts;
-        foreach (const QString &context, contextValue.split(QLatin1Char(';'), QString::SkipEmptyParts)) {
+        foreach (const QString &context, contextValue.split(QLatin1Char(';'), Qt::SkipEmptyParts)) {
             const int type = contextType(context);
             if (type != -1) {
                 contexts.append(type);

--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -2882,7 +2882,7 @@ QContactManager::Error ContactReader::readDeletedContactIds(
                 }
             } else if (filterType == QContactFilter::CollectionFilter) {
                 const QContactCollectionFilter &collectionFilter(static_cast<const QContactCollectionFilter &>(partialFilter));
-                collectionIds = collectionFilter.collectionIds().toList();
+                collectionIds = collectionFilter.collectionIds().values();
                 if (collectionIds.size() > 1) {
                     qWarning() << "Cannot readDeletedContactIds with more than one collection specified:"
                                <<  collectionIds.size();

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -3266,7 +3266,6 @@ void ContactsDatabase::Query::reportError(const char *text) const
 
 ContactsDatabase::ContactsDatabase(ContactsEngine *engine)
     : m_engine(engine)
-    , m_mutex(QMutex::Recursive)
     , m_nonprivileged(false)
     , m_autoTest(false)
     , m_localeName(QLocale().name())
@@ -3303,9 +3302,9 @@ ContactsDatabase::~ContactsDatabase()
     m_database.close();
 }
 
-QMutex *ContactsDatabase::accessMutex() const
+QRecursiveMutex *ContactsDatabase::accessMutex() const
 {
-    return const_cast<QMutex *>(&m_mutex);
+    return const_cast<QRecursiveMutex *>(&m_mutex);
 }
 
 ContactsDatabase::ProcessMutex *ContactsDatabase::processMutex() const

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -3389,7 +3389,7 @@ bool ContactsDatabase::open(const QString &connectionName, bool nonprivileged, b
     QDir databaseDir;
     if (!nonprivileged && databaseDir.mkpath(privilegedDataDirPath + databaseSubdir)) {
         // privileged.
-        databaseDir = privilegedDataDirPath + databaseSubdir;
+        databaseDir.setPath(privilegedDataDirPath + databaseSubdir);
     } else {
         // not privileged.
         if (!databaseDir.mkpath(systemDataDirPath + databaseSubdir)) {
@@ -3397,7 +3397,7 @@ bool ContactsDatabase::open(const QString &connectionName, bool nonprivileged, b
                                           .arg(systemDataDirPath + databaseSubdir));
             return false;
         }
-        databaseDir = systemDataDirPath + databaseSubdir;
+        databaseDir.setPath(systemDataDirPath + databaseSubdir);
         if (!nonprivileged) {
             QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Could not access privileged data directory; using nonprivileged"));
         }

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -1801,7 +1801,7 @@ static bool updateStorageTypes(QSqlDatabase &database)
             const quint32 detailId(query.value(0).value<quint32>());
             const QString originalSubTypes(query.value(1).value<QString>());
 
-            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), QString::SkipEmptyParts));
+            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), Qt::SkipEmptyParts));
             QStringList subTypeValues;
             foreach (int subTypeValue, Address::subTypeList(subTypeNames)) {
                 subTypeValues.append(QString::number(subTypeValue));
@@ -1949,7 +1949,7 @@ static bool updateStorageTypes(QSqlDatabase &database)
             const QString originalProtocol(query.value(1).value<QString>());
             const QString originalSubTypes(query.value(2).value<QString>());
 
-            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), QString::SkipEmptyParts));
+            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), Qt::SkipEmptyParts));
             QStringList subTypeValues;
             foreach (int subTypeValue, OnlineAccount::subTypeList(subTypeNames)) {
                 subTypeValues.append(QString::number(subTypeValue));
@@ -2000,7 +2000,7 @@ static bool updateStorageTypes(QSqlDatabase &database)
             const quint32 detailId(query.value(0).value<quint32>());
             const QString originalSubTypes(query.value(1).value<QString>());
 
-            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), QString::SkipEmptyParts));
+            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), Qt::SkipEmptyParts));
             QStringList subTypeValues;
             foreach (int subTypeValue, PhoneNumber::subTypeList(subTypeNames)) {
                 subTypeValues.append(QString::number(subTypeValue));

--- a/src/engine/contactsdatabase.h
+++ b/src/engine/contactsdatabase.h
@@ -128,7 +128,7 @@ public:
     ContactsDatabase(ContactsEngine *engine);
     ~ContactsDatabase();
 
-    QMutex *accessMutex() const;
+    QRecursiveMutex *accessMutex() const;
     ProcessMutex *processMutex() const;
 
     bool open(const QString &databaseName, bool nonprivileged, bool autoTest, bool secondaryConnection = false);
@@ -199,7 +199,7 @@ private:
     ContactsEngine *m_engine;
     QSqlDatabase m_database;
     ContactsTransientStore m_transientStore;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
     mutable QScopedPointer<ProcessMutex> m_processMutex;
     bool m_nonprivileged;
     bool m_autoTest;

--- a/src/engine/contactsengine.cpp
+++ b/src/engine/contactsengine.cpp
@@ -965,10 +965,18 @@ private:
 
 class JobThread : public QThread
 {
-    struct MutexUnlocker {
-        QMutexLocker &m_locker;
+public:
+#if QT_VERSION < 0x060000
+    using MutexLocker = QMutexLocker;
+#else
+    using MutexLocker = QMutexLocker<QMutex>;
+#endif
 
-        explicit MutexUnlocker(QMutexLocker &locker) : m_locker(locker)
+private:
+    struct MutexUnlocker {
+        MutexLocker &m_locker;
+
+        explicit MutexUnlocker(MutexLocker &locker) : m_locker(locker)
         {
             m_locker.unlock();
         }
@@ -1251,7 +1259,7 @@ void JobThread::run()
     QString dbId(QStringLiteral("qtcontacts-sqlite%1-job-%2"));
     dbId = dbId.arg(m_autoTest ? QStringLiteral("-test") : QString()).arg(m_databaseUuid);
 
-    QMutexLocker locker(&m_mutex);
+    JobThread::MutexLocker locker(&m_mutex);
 
     m_database.open(dbId, m_nonprivileged, m_autoTest);
     m_nonprivileged = m_database.nonprivileged();

--- a/src/engine/contactstransientstore.cpp
+++ b/src/engine/contactstransientstore.cpp
@@ -75,7 +75,6 @@ public:
     typedef std::tr1::function<void ()> Function;
 
     SharedMemoryManager()
-        : m_mutex(QMutex::Recursive)
     {
     }
 
@@ -181,7 +180,7 @@ private:
 
     QMap<QString, TableData> m_tables;
     QScopedPointer<Semaphore> m_semaphore;
-    QMutex m_mutex;
+    QRecursiveMutex m_mutex;
 };
 
 Q_GLOBAL_STATIC(SharedMemoryManager, sharedMemory);

--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -226,23 +226,23 @@ bool ContactWriter::commitTransaction()
         m_displayLabelGroupsChanged = false;
     }
     if (!m_addedCollectionIds.isEmpty()) {
-        m_notifier->collectionsAdded(m_addedCollectionIds.toList());
+        m_notifier->collectionsAdded(m_addedCollectionIds.values());
         m_addedCollectionIds.clear();
     }
     if (!m_changedCollectionIds.isEmpty()) {
-        m_notifier->collectionsChanged(m_changedCollectionIds.toList());
+        m_notifier->collectionsChanged(m_changedCollectionIds.values());
         m_changedCollectionIds.clear();
     }
     if (!m_addedIds.isEmpty()) {
-        m_notifier->contactsAdded(m_addedIds.toList());
+        m_notifier->contactsAdded(m_addedIds.values());
         m_addedIds.clear();
     }
     if (!m_changedIds.isEmpty()) {
-        m_notifier->contactsChanged(m_changedIds.toList());
+        m_notifier->contactsChanged(m_changedIds.values());
         m_changedIds.clear();
     }
     if (!m_presenceChangedIds.isEmpty()) {
-        m_notifier->contactsPresenceChanged(m_presenceChangedIds.toList());
+        m_notifier->contactsPresenceChanged(m_presenceChangedIds.values());
         m_presenceChangedIds.clear();
     }
     if (m_suppressedCollectionIds.size()) {
@@ -254,7 +254,7 @@ bool ContactWriter::commitTransaction()
     }
     m_suppressedCollectionIds.clear();
     if (!m_collectionContactsChanged.isEmpty()) {
-        m_notifier->collectionContactsChanged(m_collectionContactsChanged.toList());
+        m_notifier->collectionContactsChanged(m_collectionContactsChanged.values());
         m_collectionContactsChanged.clear();
     }
     if (!m_removedIds.isEmpty()) {
@@ -265,11 +265,11 @@ bool ContactWriter::commitTransaction()
         }
         m_database.removeTransientDetails(removedDbIds);
 
-        m_notifier->contactsRemoved(m_removedIds.toList());
+        m_notifier->contactsRemoved(m_removedIds.values());
         m_removedIds.clear();
     }
     if (!m_removedCollectionIds.isEmpty()) {
-        m_notifier->collectionsRemoved(m_removedCollectionIds.toList());
+        m_notifier->collectionsRemoved(m_removedCollectionIds.values());
         m_removedCollectionIds.clear();
 
     }
@@ -550,7 +550,7 @@ QContactManager::Error ContactWriter::saveRelationships(
     }
 
     if (m_database.aggregating() && !aggregatesAffected.isEmpty() && !withinAggregateUpdate) {
-        QContactManager::Error writeError = regenerateAggregates(aggregatesAffected.toList(), DetailList(), true);
+        QContactManager::Error writeError = regenerateAggregates(aggregatesAffected.values(), DetailList(), true);
         if (writeError != QContactManager::NoError) {
             return writeError;
         }
@@ -680,7 +680,7 @@ QContactManager::Error ContactWriter::removeRelationships(
         }
 
         if (!aggregatesAffected.isEmpty()) {
-            QContactManager::Error writeError = regenerateAggregates(aggregatesAffected.toList(), DetailList(), true);
+            QContactManager::Error writeError = regenerateAggregates(aggregatesAffected.values(), DetailList(), true);
             if (writeError != QContactManager::NoError)
                 return writeError;
         }

--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -32,6 +32,7 @@
 
 #include "contactwriter.h"
 
+#include "compat.h"
 #include "contactsengine.h"
 #include "contactreader.h"
 #include "trace_p.h"
@@ -1932,7 +1933,7 @@ bool ContactWriter::storeOOB(const QString &scope, const QMap<QString, QVariant>
 
         // If the data is large, compress it to reduce the IO cost
         const QVariant &var(it.value());
-        if (var.type() == static_cast<QVariant::Type>(QMetaType::QByteArray)) {
+        if (isByteArray(var)) {
             const QByteArray uncompressed(var.value<QByteArray>());
             if (uncompressed.size() > 512) {
                 // Test the entropy of this data, if it is unlikely to compress significantly, don't try
@@ -1942,7 +1943,7 @@ bool ContactWriter::storeOOB(const QString &scope, const QMap<QString, QVariant>
                     continue;
                 }
             }
-        } else if (var.type() == static_cast<QVariant::Type>(QMetaType::QString)) {
+        } else if (isString(var)) {
             const QString uncompressed(var.value<QString>());
             if (uncompressed.size() > 256) {
                 dataValues.append(QVariant(qCompress(uncompressed.toUtf8())));

--- a/src/extensions/compat.h
+++ b/src/extensions/compat.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Adriaan de Groot <groot@kde.org>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+#ifndef EXTENSIONS_COMPAT_H
+#define EXTENSIONS_COMPAT_H
+
+#include <QVariant>
+
+/**
+ * @file
+ *
+ * Defines functions for doing QVariant type-checking. (Long) Before
+ * Qt 5.14, using v.type() == QVariant::<type-id> was the way to go,
+ * but now it is QMetaType that is responsible for the type-ids.
+ *
+ * Introduce convenience functions for common "is-this-a ..." questions.
+ */
+
+[[nodiscard]] inline bool isVariantType(const QVariant & v, QMetaType::Type type)
+{
+#if QT_VERSION < 0x060000
+    return v.type() == static_cast<QVariant::Type>(type);
+#else
+    return v.typeId() == type;
+#endif
+}
+
+[[nodiscard]] inline bool isString(const QVariant & v)
+{
+    return isVariantType(v,QMetaType::QString);
+}
+
+[[nodiscard]] inline bool isInvalid(const QVariant & v)
+{
+    return isVariantType(v,QMetaType::UnknownType);
+}
+
+[[nodiscard]] inline bool isByteArray(const QVariant & v)
+{
+    return isVariantType(v,QMetaType::QByteArray);
+}
+
+[[nodiscard]] inline bool isUrl(const QVariant & v)
+{
+    return isVariantType(v,QMetaType::QUrl);
+}
+
+#endif

--- a/src/extensions/contactdelta_impl.h
+++ b/src/extensions/contactdelta_impl.h
@@ -473,9 +473,9 @@ QList<QContactDetail> improveDelta(
     QMultiHash<int, QContactDetail> bucketedAdditions;
 
     for (int i = 0; i < removals->size(); ++i)
-        bucketedRemovals.insertMulti(removals->at(i).type(), removals->at(i));
+        bucketedRemovals.insert(removals->at(i).type(), removals->at(i));
     for (int i = 0; i < additions->size(); ++i)
-        bucketedAdditions.insertMulti(additions->at(i).type(), additions->at(i));
+        bucketedAdditions.insert(additions->at(i).type(), additions->at(i));
 
     QSet<int> seenTypes;
     foreach (int type, bucketedRemovals.uniqueKeys()) {

--- a/src/extensions/contactdelta_impl.h
+++ b/src/extensions/contactdelta_impl.h
@@ -33,6 +33,8 @@
 #ifndef CONTACTDELTA_IMPL_H
 #define CONTACTDELTA_IMPL_H
 
+#include "compat.h"
+
 #include <contactdelta.h>
 #include <qtcontacts-extensions.h>
 #include <contactmanagerengine.h>
@@ -125,8 +127,8 @@ void removeDatabaseIdsFromList(QList<QContactDetail> *dets)
 int scoreForValuePair(const QVariant &removal, const QVariant &addition)
 {
     // work around some variant-comparison issues.
-    if (Q_UNLIKELY((((removal.type() == QVariant::String && addition.type() == QVariant::Invalid)
-                   ||(addition.type() == QVariant::String && removal.type() == QVariant::Invalid))
+    if (Q_UNLIKELY((((isString(removal) && isInvalid(addition))
+                   ||(isString(addition) && isInvalid(removal)))
                    &&(removal.toString().isEmpty() && addition.toString().isEmpty())))) {
         // it could be that "invalid" variant is stored as an empty
         // string in database, if the field is a string field.
@@ -143,11 +145,11 @@ int scoreForValuePair(const QVariant &removal, const QVariant &addition)
     }
 
     // the sync adaptor might return url data as a string.
-    if (removal.type() == QVariant::Url && addition.type() == QVariant::String) {
+    if (isUrl(removal) && isString(addition)) {
         QUrl rurl = removal.toUrl();
         QUrl aurl = QUrl(addition.toString());
         return rurl == aurl ? 0 : 1;
-    } else if (removal.type() == QVariant::String && addition.type() == QVariant::Url) {
+    } else if (isString(removal) && isUrl(addition)) {
         QUrl rurl = QUrl(removal.toString());
         QUrl aurl = addition.toUrl();
         return rurl == aurl ? 0 : 1;
@@ -216,8 +218,8 @@ bool detailPairExactlyMatches(
             // or if the avalue is an empty string, or empty list,
             // as the database can sometimes return empty
             // string instead of NULL value.
-            if (avalue.type() == QVariant::Invalid
-                    || (avalue.type() == QVariant::String && avalue.toString().isEmpty())
+            if (isInvalid(avalue)
+                    || (isString(avalue) && avalue.toString().isEmpty())
                     || (avalue.userType() == QMetaType::type("QList<int>") && avalue.value<QList<int> >() == QList<int>())) {
                 // this is ok.
             } else {
@@ -250,8 +252,8 @@ bool detailPairExactlyMatches(
         }
 
         const QVariant bvalue = bvalues.value(bkey);
-        if (bvalue.type() == QVariant::Invalid
-                || (bvalue.type() == QVariant::String && bvalue.toString().isEmpty())
+        if (isInvalid(bvalue)
+                || (isString(bvalue) && bvalue.toString().isEmpty())
                 || (bvalue.userType() == QMetaType::type("QList<int>") && bvalue.value<QList<int> >() == QList<int>())) {
             // this is ok.
         } else {

--- a/tests/benchmarks/fetchtimes/main.cpp
+++ b/tests/benchmarks/fetchtimes/main.cpp
@@ -55,6 +55,7 @@
 #include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QDateTime>
+#include <QRandomGenerator>
 #include <QUuid>
 #include <QtDebug>
 
@@ -192,6 +193,22 @@ static QStringList generateHobbiesList()
     return retn;
 }
 
+static QRandomGenerator & getRG()
+{
+    static QRandomGenerator g;
+    return g;
+}
+
+static int nextRandom()
+{
+    return getRG().generate();
+}
+
+static void seedRandom(int seed)
+{
+    getRG().seed(seed);
+}
+
 QContact generateContact(const QContactCollectionId &collectionId = QContactCollectionId(), bool possiblyAggregate = false)
 {
     static const QStringList firstNames(generateFirstNamesList());
@@ -208,7 +225,7 @@ QContact generateContact(const QContactCollectionId &collectionId = QContactColl
     // to ensure that we have heterogeneous contacts in the db.
     QContact retn;
     retn.setCollectionId(collectionId);
-    int random = qrand();
+    int random = nextRandom();
     bool preventAggregate = (!collectionId.isNull() && !possiblyAggregate);
 
     // We always have a name.  Select an overlapping name if the sync target
@@ -264,7 +281,7 @@ QContact generateContact(const QContactCollectionId &collectionId = QContactColl
         h1.setHobby(hobbies.at(random % hobbies.size()));
         retn.saveDetail(&h1);
 
-        int newRandom = qrand();
+        int newRandom = nextRandom();
         if ((newRandom % 2) == 0) {
             QContactHobby h2;
             h2.setHobby(hobbies.at(newRandom % hobbies.size()));
@@ -345,9 +362,9 @@ static qint64 aggregatedPresenceUpdate(QContactManager &manager, bool quickMode)
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(timestamp);
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -369,7 +386,7 @@ static qint64 aggregatedPresenceUpdate(QContactManager &manager, bool quickMode)
     for (int j = 0; j < morePrefillData.size(); ++j) {
         QContact curr = morePrefillData.at(j);
         QContactPresence cp = curr.detail<QContactPresence>();
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         curr.saveDetail(&cp);
         contactsToUpdate.append(curr);
     }
@@ -390,7 +407,7 @@ static qint64 aggregatedPresenceUpdate(QContactManager &manager, bool quickMode)
     for (int j = 0; j < morePrefillData.size(); ++j) {
         QContact curr = morePrefillData.at(j);
         QContactPresence cp = curr.detail<QContactPresence>();
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         curr.saveDetail(&cp);
         contactsToUpdate.append(curr);
     }
@@ -488,9 +505,9 @@ static qint64 nonAggregatedPresenceUpdate(QContactManager &manager, bool quickMo
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(timestamp);
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -572,9 +589,9 @@ static qint64 scalingPresenceUpdate(QContactManager &manager, bool quickMode)
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(timestamp);
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -653,9 +670,9 @@ static qint64 entireBatchPresenceUpdate(QContactManager &manager, bool quickMode
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(timestamp);
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -739,9 +756,9 @@ static qint64 smallBatchPresenceUpdate(QContactManager &manager, bool quickMode)
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(QDateTime::currentDateTime());
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>(qrand() % 4));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>(nextRandom() % 4));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -1838,19 +1855,19 @@ int main(int argc, char  *argv[])
     if (queryPlan) {
         // hidden/undocumented feature: perform two writes and one read
         // which we will use to inspect the query plans.
-        qsrand(42);
+        seedRandom(42);
         elapsedTimeTotal = performQueryPlanOperations(manager);
     } else if (readTestData) {
         // hidden/undocumented feature: time read all contacts from database.
-        qsrand(42);
+        seedRandom(42);
         elapsedTimeTotal = performReadQueryPlanTestData(manager);
     } else if (testData) {
         // hidden/undocumented feature: fill database with random data
         // which we then use to generate the query plan.
-        qsrand(42);
+        seedRandom(42);
         elapsedTimeTotal = generateQueryPlanTestData(manager, args.last().toInt());
     } else {
-        qsrand(stable ? 42 : QDateTime::currentDateTime().time().second());
+        seedRandom(stable ? 42 : QDateTime::currentDateTime().time().second());
         elapsedTimeTotal += (runAll || functionArgs.contains("simpleFilterAndSort")) ? simpleFilterAndSort(manager, quickMode) : 0;
         elapsedTimeTotal += (runAll || functionArgs.contains("asynchronousOperations")) ? asynchronousOperations(manager, quickMode) : 0;
         elapsedTimeTotal += (runAll || functionArgs.contains("synchronousOperations")) ? synchronousOperations(manager, quickMode) : 0;


### PR DESCRIPTION
This is a handful of commits that reduces the amount of compiler warnings about deprecated Qt5 API use (in Debian 13, anyway) when compiling this plugin against the Qt5 PIM suite and Qt 5.15 base. Each commit chases one class / API that has changed.

Note that not **all** warnings are resolved: there's lots of hidden functions (marked virtual, not override, and which hide base-class virtuals with more-specific types).