### PR TITLE
Reduce Qt deprecation warnings

### DIFF
--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -38,6 +38,8 @@
 #include "../extensions/qcontactoriginmetadata.h"
 #include "../extensions/qcontactstatusflags.h"
 
+#include "compat.h"
+
 #include <QContactAddress>
 #include <QContactAnniversary>
 #include <QContactAvatar>
@@ -134,7 +136,7 @@ static QVariant stringListValue(const QVariant &columnValue)
         return columnValue;
 
     QString listString(columnValue.toString());
-    return listString.split(QLatin1Char(';'), QString::SkipEmptyParts);
+    return listString.split(QLatin1Char(';'), compat::SkipEmptyParts);
 }
 
 static QVariant urlValue(const QVariant &columnValue)
@@ -204,7 +206,7 @@ static void setValues(QContactAddress *detail, QSqlQuery *query, const int offse
     setValue(detail, T::FieldLocality     , query->value(offset + 3));
     setValue(detail, T::FieldPostcode     , query->value(offset + 4));
     setValue(detail, T::FieldCountry      , query->value(offset + 5));
-    const QStringList subTypeValues(query->value(offset + 6).toString().split(QLatin1Char(';'), QString::SkipEmptyParts));
+    const QStringList subTypeValues(query->value(offset + 6).toString().split(QLatin1Char(';'), compat::SkipEmptyParts));
     setValue(detail, T::FieldSubTypes     , QVariant::fromValue<QList<int> >(subTypeList(subTypeValues)));
 }
 
@@ -305,7 +307,7 @@ static void setValues(QContactFamily *detail, QSqlQuery *query, const int offset
     typedef QContactFamily T;
 
     setValue(detail, T::FieldSpouse  , query->value(offset + 0));
-    setValue(detail, T::FieldChildren, query->value(offset + 1).toString().split(QLatin1Char(';'), QString::SkipEmptyParts));
+    setValue(detail, T::FieldChildren, query->value(offset + 1).toString().split(QLatin1Char(';'), compat::SkipEmptyParts));
 }
 
 static const FieldInfo favoriteFields[] =
@@ -462,7 +464,7 @@ static void setValues(QContactOnlineAccount *detail, QSqlQuery *query, const int
     setValue(detail, T::FieldServiceProvider, query->value(offset + 3));
     setValue(detail, T::FieldCapabilities   , stringListValue(query->value(offset + 4)));
 
-    const QStringList subTypeValues(query->value(offset + 5).toString().split(QLatin1Char(';'), QString::SkipEmptyParts));
+    const QStringList subTypeValues(query->value(offset + 5).toString().split(QLatin1Char(';'), compat::SkipEmptyParts));
     setValue(detail, T::FieldSubTypes, QVariant::fromValue<QList<int> >(subTypeList(subTypeValues)));
 
     setValue(detail, QContactOnlineAccount__FieldAccountPath,                query->value(offset + 6));
@@ -509,7 +511,7 @@ static void setValues(QContactPhoneNumber *detail, QSqlQuery *query, const int o
 
     setValue(detail, T::FieldNumber  , query->value(offset + 0));
 
-    const QStringList subTypeValues(query->value(offset + 1).toString().split(QLatin1Char(';'), QString::SkipEmptyParts));
+    const QStringList subTypeValues(query->value(offset + 1).toString().split(QLatin1Char(';'), compat::SkipEmptyParts));
     setValue(detail, T::FieldSubTypes, QVariant::fromValue<QList<int> >(subTypeList(subTypeValues)));
 
     setValue(detail, QContactPhoneNumber::FieldNormalizedNumber, query->value(offset + 2));
@@ -710,11 +712,11 @@ static void readDetail(QContact *contact, QSqlQuery &query, quint32 contactId, q
     if (!linkedDetailUrisValue.isEmpty()) {
         setValue(&detail,
                  QContactDetail::FieldLinkedDetailUris,
-                 linkedDetailUrisValue.split(QLatin1Char(';'), QString::SkipEmptyParts));
+                 linkedDetailUrisValue.split(QLatin1Char(';'), compat::SkipEmptyParts));
     }
     if (!contextValue.isEmpty()) {
         QList<int> contexts;
-        foreach (const QString &context, contextValue.split(QLatin1Char(';'), QString::SkipEmptyParts)) {
+        foreach (const QString &context, contextValue.split(QLatin1Char(';'), compat::SkipEmptyParts)) {
             const int type = contextType(context);
             if (type != -1) {
                 contexts.append(type);

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -36,6 +36,8 @@
 #include "conversion_p.h"
 #include "trace_p.h"
 
+#include "compat.h"
+
 #include <QContactGender>
 #include <QContactName>
 #include <QContactDisplayLabel>
@@ -1801,7 +1803,7 @@ static bool updateStorageTypes(QSqlDatabase &database)
             const quint32 detailId(query.value(0).value<quint32>());
             const QString originalSubTypes(query.value(1).value<QString>());
 
-            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), QString::SkipEmptyParts));
+            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), compat::SkipEmptyParts));
             QStringList subTypeValues;
             foreach (int subTypeValue, Address::subTypeList(subTypeNames)) {
                 subTypeValues.append(QString::number(subTypeValue));
@@ -1949,7 +1951,7 @@ static bool updateStorageTypes(QSqlDatabase &database)
             const QString originalProtocol(query.value(1).value<QString>());
             const QString originalSubTypes(query.value(2).value<QString>());
 
-            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), QString::SkipEmptyParts));
+            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), compat::SkipEmptyParts));
             QStringList subTypeValues;
             foreach (int subTypeValue, OnlineAccount::subTypeList(subTypeNames)) {
                 subTypeValues.append(QString::number(subTypeValue));
@@ -2000,7 +2002,7 @@ static bool updateStorageTypes(QSqlDatabase &database)
             const quint32 detailId(query.value(0).value<quint32>());
             const QString originalSubTypes(query.value(1).value<QString>());
 
-            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), QString::SkipEmptyParts));
+            QStringList subTypeNames(originalSubTypes.split(QLatin1Char(';'), compat::SkipEmptyParts));
             QStringList subTypeValues;
             foreach (int subTypeValue, PhoneNumber::subTypeList(subTypeNames)) {
                 subTypeValues.append(QString::number(subTypeValue));

--- a/src/extensions/compat.h
+++ b/src/extensions/compat.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 Adriaan de Groot <groot@kde.org>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef EXTENSIONS_COMPAT_H
+#define EXTENSIONS_COMPAT_H
+
+
+#endif

--- a/src/extensions/compat.h
+++ b/src/extensions/compat.h
@@ -30,5 +30,18 @@
 #ifndef EXTENSIONS_COMPAT_H
 #define EXTENSIONS_COMPAT_H
 
+#include <QString>
+
+namespace compat
+{
+
+///@brief SkipEmptyParts when splitting strings
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
+    static constexpr auto SkipEmptyParts = QString::SkipEmptyParts;
+#else
+    static constexpr auto SkipEmptyParts = Qt::SkipEmptyParts;
+#endif
+
+}
 
 #endif

--- a/tests/benchmarks/fetchtimes/main.cpp
+++ b/tests/benchmarks/fetchtimes/main.cpp
@@ -192,6 +192,36 @@ static QStringList generateHobbiesList()
     return retn;
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
+static int nextRandom()
+{
+    return qrand();
+}
+
+static void seedRandom(int seed)
+{
+    qsrand(seed);
+}
+#else
+#include <QRandomGenerator>
+
+static QRandomGenerator & getRG()
+{
+    static QRandomGenerator g;
+    return g;
+}
+
+static int nextRandom()
+{
+    return getRG().generate();
+}
+
+static void seedRandom(int seed)
+{
+    getRG().seed(seed);
+}
+#endif
+
 QContact generateContact(const QContactCollectionId &collectionId = QContactCollectionId(), bool possiblyAggregate = false)
 {
     static const QStringList firstNames(generateFirstNamesList());
@@ -208,7 +238,7 @@ QContact generateContact(const QContactCollectionId &collectionId = QContactColl
     // to ensure that we have heterogeneous contacts in the db.
     QContact retn;
     retn.setCollectionId(collectionId);
-    int random = qrand();
+    int random = nextRandom();
     bool preventAggregate = (!collectionId.isNull() && !possiblyAggregate);
 
     // We always have a name.  Select an overlapping name if the sync target
@@ -264,7 +294,7 @@ QContact generateContact(const QContactCollectionId &collectionId = QContactColl
         h1.setHobby(hobbies.at(random % hobbies.size()));
         retn.saveDetail(&h1);
 
-        int newRandom = qrand();
+        int newRandom = nextRandom();
         if ((newRandom % 2) == 0) {
             QContactHobby h2;
             h2.setHobby(hobbies.at(newRandom % hobbies.size()));
@@ -345,9 +375,9 @@ static qint64 aggregatedPresenceUpdate(QContactManager &manager, bool quickMode)
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(timestamp);
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -369,7 +399,7 @@ static qint64 aggregatedPresenceUpdate(QContactManager &manager, bool quickMode)
     for (int j = 0; j < morePrefillData.size(); ++j) {
         QContact curr = morePrefillData.at(j);
         QContactPresence cp = curr.detail<QContactPresence>();
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         curr.saveDetail(&cp);
         contactsToUpdate.append(curr);
     }
@@ -390,7 +420,7 @@ static qint64 aggregatedPresenceUpdate(QContactManager &manager, bool quickMode)
     for (int j = 0; j < morePrefillData.size(); ++j) {
         QContact curr = morePrefillData.at(j);
         QContactPresence cp = curr.detail<QContactPresence>();
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         curr.saveDetail(&cp);
         contactsToUpdate.append(curr);
     }
@@ -488,9 +518,9 @@ static qint64 nonAggregatedPresenceUpdate(QContactManager &manager, bool quickMo
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(timestamp);
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -572,9 +602,9 @@ static qint64 scalingPresenceUpdate(QContactManager &manager, bool quickMode)
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(timestamp);
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -653,9 +683,9 @@ static qint64 entireBatchPresenceUpdate(QContactManager &manager, bool quickMode
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(timestamp);
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((qrand() % 4) + 1));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>((nextRandom() % 4) + 1));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -739,9 +769,9 @@ static qint64 smallBatchPresenceUpdate(QContactManager &manager, bool quickMode)
         cp.setNickname(genstr);
         cp.setCustomMessage(genstr);
         cp.setTimestamp(QDateTime::currentDateTime());
-        cp.setPresenceState(static_cast<QContactPresence::PresenceState>(qrand() % 4));
+        cp.setPresenceState(static_cast<QContactPresence::PresenceState>(nextRandom() % 4));
         nn.setNickname(nn.nickname() + genstr);
-        av.setImageUrl(genstr + presenceAvatars.at(qrand() % presenceAvatars.size()));
+        av.setImageUrl(genstr + presenceAvatars.at(nextRandom() % presenceAvatars.size()));
         curr.saveDetail(&cp);
         curr.saveDetail(&nn);
         curr.saveDetail(&av);
@@ -1838,19 +1868,19 @@ int main(int argc, char  *argv[])
     if (queryPlan) {
         // hidden/undocumented feature: perform two writes and one read
         // which we will use to inspect the query plans.
-        qsrand(42);
+        seedRandom(42);
         elapsedTimeTotal = performQueryPlanOperations(manager);
     } else if (readTestData) {
         // hidden/undocumented feature: time read all contacts from database.
-        qsrand(42);
+        seedRandom(42);
         elapsedTimeTotal = performReadQueryPlanTestData(manager);
     } else if (testData) {
         // hidden/undocumented feature: fill database with random data
         // which we then use to generate the query plan.
-        qsrand(42);
+        seedRandom(42);
         elapsedTimeTotal = generateQueryPlanTestData(manager, args.last().toInt());
     } else {
-        qsrand(stable ? 42 : QDateTime::currentDateTime().time().second());
+        seedRandom(stable ? 42 : QDateTime::currentDateTime().time().second());
         elapsedTimeTotal += (runAll || functionArgs.contains("simpleFilterAndSort")) ? simpleFilterAndSort(manager, quickMode) : 0;
         elapsedTimeTotal += (runAll || functionArgs.contains("asynchronousOperations")) ? asynchronousOperations(manager, quickMode) : 0;
         elapsedTimeTotal += (runAll || functionArgs.contains("synchronousOperations")) ? synchronousOperations(manager, quickMode) : 0;


### PR DESCRIPTION
This is a second take based on MR #12 , which deals with only **some** of the deprecation warnings -- but I'm pretty sure it retains compatibility with Qt 5.6 and C++11. These are the slightly simpler warnings to deal with. If this works, then I can try to chase the other bits (which are more complicated, for sure) as well.