### PR TITLE
ContactReader: support case insensitive search

### DIFF
--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -1161,10 +1161,8 @@ static QString buildWhere(
             globValue = QContactFilter::MatchContains;
         }
 
-        // We need to perform case-insensitive matching if MatchFixedString is specified (unless
-        // CaseSensitive is also specified)
+        // We need to perform case-insensitive matching unless CaseSensitive is specified
         bool caseInsensitive = stringField
-                               && fixedString
                                && ((filter.matchFlags() & QContactFilter::MatchCaseSensitive) == 0);
 
         QString clause(detail.where(queryContacts));
@@ -1318,7 +1316,6 @@ static QString buildWhere(const QContactDetailRangeFilter &filter, bool queryCon
     bool dateField = field.fieldType == DateField;
     bool stringField = field.fieldType == StringField || field.fieldType == LocalizedField;
     bool caseInsensitive = stringField
-                           && filter.matchFlags() & QContactFilter::MatchFixedString
                            && (filter.matchFlags() & QContactFilter::MatchCaseSensitive) == 0;
 
     bool needsAnd = false;

--- a/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
+++ b/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
@@ -4987,7 +4987,7 @@ void tst_QContactManager::searchSensitivity()
     QCOMPARE(m->contactIds().count(), currCount+1);
 
     QCOMPARE(m->contactIds(exactMatch).count(), originalCount[0] + 1);
-    QCOMPARE(m->contactIds(exactMismatch).count(), originalCount[1]);
+    QCOMPARE(m->contactIds(exactMismatch).count(), originalCount[1] + 1);
     QCOMPARE(m->contactIds(insensitiveMatch).count(), originalCount[2] + 1);
     QCOMPARE(m->contactIds(insensitiveMismatch).count(), originalCount[3] + 1);
     QCOMPARE(m->contactIds(sensitiveMatch).count(), originalCount[4] + 1);


### PR DESCRIPTION
It's not clear why the case insensitive filter was limited to the MatchFixedString, as that makes it impossible to implement a contact search. 

This is a rebase of !2 as I don't have permission to push to that branch.